### PR TITLE
Fix a race condition that causes login to fail to fetch user profile

### DIFF
--- a/backend/api-gateway/main.py
+++ b/backend/api-gateway/main.py
@@ -15,6 +15,13 @@ firebase_admin.initialize_app(cred)
 
 app = FastAPI(title="PeerPrep API Gateway")
 
+http_client = httpx.AsyncClient()
+
+@app.on_event("shutdown")
+async def shutdown_event():
+    """Clean up the httpx client when the application shuts down."""
+    await http_client.aclose()
+
 # app.add_middleware(
 #     CORSMiddleware,
 #     allow_origins=["*"],
@@ -48,18 +55,19 @@ async def verify_token(request: Request):
         raise HTTPException(status_code=401, detail="Missing or invalid Authorization header")
     
     token = auth_header.split(" ")[1]
+    
     try:
         decoded_token = auth.verify_id_token(token)
-
-        if not decoded_token.get("email_verified"):
-            raise HTTPException(
-                status_code=403, 
-                detail="Email not verified. Please check your inbox."
-            )
-        
-        return decoded_token
     except Exception as e:
         raise HTTPException(status_code=401, detail=f"Invalid token: {str(e)}")
+
+    if not decoded_token.get("email_verified"):
+        raise HTTPException(
+            status_code=403, 
+            detail="Email not verified. Please check your inbox."
+        )
+    
+    return decoded_token
 
 @app.api_route("/{path:path}", methods=["GET", "POST", "PUT", "PATCH", "DELETE"])
 async def gateway_proxy(request: Request, path: str):
@@ -100,17 +108,16 @@ async def gateway_proxy(request: Request, path: str):
 
     body = await request.body()
     
-    async with httpx.AsyncClient() as client:
-        try:
-            target_response = await client.request(
-                method=request.method,
-                url=target_url,
-                headers=forwarded_headers,
-                content=body,
-                timeout=10.0
-            )
-        except httpx.RequestError as e:
-            raise HTTPException(status_code=503, detail=f"Target service unavailable: {str(e)}")
+    try:
+        target_response = await http_client.request(
+            method=request.method,
+            url=target_url,
+            headers=forwarded_headers,
+            content=body,
+            timeout=10.0
+        )
+    except httpx.RequestError as e:
+        raise HTTPException(status_code=503, detail=f"Target service unavailable: {str(e)}")
 
     return Response(
         content=target_response.content,

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -18,7 +18,7 @@ export default function App() {
   const [matchingCriteria, setMatchingCriteria] = useState<any>(null);
   const [session, setSession] = useState<any>(null);
 
-  // --- SESSION REHYDRATION ---
+  // --- SESSION REHYDRATION & LOGIN HANDLING ---
   useEffect(() => {
     const unsubscribe = onAuthStateChanged(auth, async (firebaseUser) => {
       if (firebaseUser) {
@@ -38,9 +38,12 @@ export default function App() {
               avatar: `https://api.dicebear.com/7.x/avataaars/svg?seed=${profileData.email}`
             });
             setCurrentPage('dashboard');
+          } else {
+             // Handle case where Firebase user exists but DB profile is missing/fails
+             console.error("Failed to fetch user profile from gateway");
           }
         } catch (err) {
-          console.error("Session restore failed:", err);
+          console.error("Session restore/login failed:", err);
         }
       } else {
         setUser(null);
@@ -50,11 +53,6 @@ export default function App() {
     });
     return () => unsubscribe();
   }, []);
-
-  const handleLogin = (userData: any) => {
-    setUser(userData);
-    setCurrentPage('dashboard');
-  };
 
   const handleLogout = async () => {
     await signOut(auth);
@@ -88,7 +86,7 @@ export default function App() {
       )}
       
       {currentPage === 'auth' && (
-        <AuthPage onLogin={handleLogin} onBack={() => setCurrentPage('landing')} />
+        <AuthPage onBack={() => setCurrentPage('landing')} />
       )}
       
       {currentPage === 'dashboard' && (

--- a/frontend/src/components/AuthPage.tsx
+++ b/frontend/src/components/AuthPage.tsx
@@ -4,13 +4,12 @@ import { signInWithEmailAndPassword } from 'firebase/auth';
 import { auth } from '../firebase';
 
 interface AuthPageProps {
-  onLogin: (user: any) => void;
   onBack: () => void;
 }
 
 const GATEWAY_URL = 'http://localhost/api';
 
-export function AuthPage({ onLogin, onBack }: AuthPageProps) {
+export function AuthPage({ onBack }: AuthPageProps) {
   const [isLogin, setIsLogin] = useState(true);
   const [showPassword, setShowPassword] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
@@ -44,7 +43,25 @@ export function AuthPage({ onLogin, onBack }: AuthPageProps) {
     e.preventDefault();
     const newErrors: any = {};
 
-    // (Validation logic remains the same)
+    if (!isLogin) {
+      if (!validateUsername(formData.username)) {
+        newErrors.username = 'Username must be 1-25 characters (letters, numbers, _, -)';
+      }
+      if (!validatePassword(formData.password)) {
+        newErrors.password = 'Password must be 8-25 characters and contain both letters and numbers';
+      }
+      if (formData.password !== formData.confirmPassword) {
+        newErrors.confirmPassword = 'Passwords do not match';
+      }
+    }
+
+    if (!isLogin && !validateEmail(formData.email)) {
+      newErrors.email = 'Please enter a valid email address';
+    } else if (isLogin && !formData.email) {
+      newErrors.email = 'Email or Username is required';
+    }
+
+    setErrors(newErrors);
 
     if (Object.keys(newErrors).length === 0) {
       setIsLoading(true);
@@ -69,25 +86,6 @@ export function AuthPage({ onLogin, onBack }: AuthPageProps) {
             await auth.signOut();
             throw new Error('Please verify your email before logging in. Check your inbox!');
           }
-
-          const token = await firebaseUser.getIdToken();
-          localStorage.setItem('peerprep_token', token);
-
-          const profileRes = await fetch(`${GATEWAY_URL}/users/${userCredential.user.uid}`, {
-            headers: { 'Authorization': `Bearer ${token}` }
-          });
-
-          if (!profileRes.ok) throw new Error('Failed to fetch user profile');
-          const profileData = await profileRes.json();
-
-          onLogin({
-            uid: userCredential.user.uid,
-            username: profileData.username,
-            email: profileData.email,
-            avatarId: profileData.avatar_id,
-            role: profileData.role,
-            avatar: `https://api.dicebear.com/7.x/avataaars/svg?seed=${profileData.email}`
-          });
 
         } else {
           // --- 2. REGISTRATION FLOW ---


### PR DESCRIPTION
This PR resolves occasional `503 Service Unavailable` and `auth/invalid-credential` errors during the login flow. The core issue was a race condition caused by `AuthPage` and `App` simultaneously trying to fetch the user profile, which bottlenecked the API Gateway. Auth state management has been centralized, and Gateway connection pooling has been optimized.

## Key Changes:
1. `api-gateway:`
Replaced per-request `httpx.AsyncClient()` with a global client. Now this client works for every single request, without having to stop and recreate for each request.

2. `App.tsx:`
Centralized Auth state and allow `Auth` to handle the fetch user request from the gateway.

3. `AuthModal.tsx:`
Stripped out the duplicate profile-fetching logic and the `onLogin` variable, allowing `App.tsx` to handle the post-login state cleanly without double-fetching.

Fixes #39.