### PR TITLE
Question service enhancements

### DIFF
--- a/backend/question-service/app/api/routes.py
+++ b/backend/question-service/app/api/routes.py
@@ -6,7 +6,7 @@ from google.cloud import firestore
 from google.cloud.firestore_v1.base_query import FieldFilter
 
 from app.database import db
-from app.models.domain import Question, QuestionCreate, QuestionUpdate
+from app.models.domain import PaginatedQuestions, Question, QuestionCreate, QuestionUpdate
 
 router = APIRouter()
 
@@ -18,67 +18,6 @@ def verify_admin(x_user_role: Optional[str]):
             status_code=status.HTTP_403_FORBIDDEN, 
             detail="Admin privileges required"
         )
-
-
-# Get a random question ID based on a given topic and difficulty level
-@router.get("/", response_model=dict)
-async def read_questions(
-    topic: str, 
-    difficulty: str
-):
-    topic = topic.strip().title()
-    difficulty = difficulty.strip().title()
-    
-    questions_ref = db.collection("questions")
-    query = questions_ref.where(
-        filter=FieldFilter("topic", "==", topic)
-    ).where(
-        filter=FieldFilter("difficulty", "==", difficulty)
-    )
-
-    # fetch only the document IDs
-    docs = query.select([]).stream()
-    doc_ids = [doc.id for doc in docs]
-
-    if not doc_ids:
-        raise HTTPException(
-            status_code=404, 
-            detail=f"No questions found for {topic} with {difficulty} difficulty"
-        )
-
-    randomQuestion_id = random.choice(doc_ids)
-
-    return {"question_id": randomQuestion_id}
-
-    
-
-# @router.get("/brew", status_code=418)
-# async def brew():
-#     return {"detail": "I'm a teapot! The requested entity body is short and stout. Tip me over and pour me out!"}
-
-# Get specific question by ID
-# This endpoint is expected to be used by question-history service to fetch question details for a given question_id.
-@router.get("/{question_id}", response_model=Question)
-async def read_question(question_id: str):
-    questions_ref = db.collection("questions")
-
-    # Fetch the question
-    doc_ref = questions_ref.document(question_id)
-    doc = doc_ref.get()
-
-    if not doc.exists:
-        raise HTTPException(
-            status_code=404, 
-            detail=f"Question not found with ID: {question_id}"
-        )
-
-    question_data = doc.to_dict()
-    
-    # Add the document ID to the returned data for consistency with the Question model
-    question_data["question_id"] = doc.id
-
-    return question_data
-
 
 # --- ADMIN ENDPOINTS ---
 
@@ -93,9 +32,8 @@ async def create_question(
     verify_admin(x_user_role)
 
     questions_ref = db.collection("questions")
-    doc_ref = questions_ref.order_by("question_id", direction=firestore.Query.DESCENDING).limit(1)
-    doc = doc_ref.get()
-    question_id = int(doc[0].to_dict().get("question_id"))+1 if doc else 1
+    docs = questions_ref.order_by("question_id", direction=firestore.Query.DESCENDING).limit(1).get()
+    question_id = int(docs[0].to_dict().get("question_id", 0)) + 1 if docs else 1
 
     question_dict = question.model_dump()
     question_dict["topic"] = question_dict["topic"].strip().title()
@@ -103,7 +41,7 @@ async def create_question(
 
     
 
-    new_question = {**question_dict, "question_id": str(question_id)}
+    new_question = {**question_dict, "question_id": question_id}
 
     # Save to Firestore
     questions_ref.document(str(question_id)).set(new_question, merge=True)
@@ -167,3 +105,149 @@ async def delete_question(
 
     return None
 
+# Endpoint to fetch all unique topics for filtering options in the frontend
+@router.get("/topics", response_model=list[str])
+def get_topics():
+    docs = db.collection("questions").select(["topic"]).stream()
+    unique_topics = set()
+    for doc in docs:
+        topic = doc.to_dict().get("topic")
+        if topic:
+            unique_topics.add(topic)
+            
+    return sorted(list(unique_topics))
+
+# Endpoint to fetch all unique difficulties for filtering options in the frontend
+@router.get("/difficulties", response_model=list[str])
+def get_difficulties():
+    docs = db.collection("questions").select(["difficulty"]).stream()
+    unique_diffs = set()
+    for doc in docs:
+        diff = doc.to_dict().get("difficulty")
+        if diff:
+            unique_diffs.add(diff)            
+    # Custom sort order
+    order = {"Easy": 0, "Medium": 1, "Hard": 2}
+    return sorted(list(unique_diffs), key=lambda x: order.get(x, 99))
+
+@router.get("/all", response_model=PaginatedQuestions)
+async def get_all_questions(
+    page: int = 1,
+    page_size: int = 10,
+    qid: Optional[str] = None,
+    topic: Optional[str] = None,
+    difficulty: Optional[str] = None
+):
+    query = db.collection("questions")
+
+    if qid:
+        doc = query.document(str(qid)).get()
+        if doc.exists:
+            q_data = doc.to_dict()
+            # Filter the keys to match your metadata select
+            filtered_data = {
+                "question_id": str(q_data.get("question_id", qid)),
+                "title": q_data.get("title", ""),
+                "topic": q_data.get("topic", ""),
+                "difficulty": q_data.get("difficulty", "")
+            }
+            return {
+                "questions": [filtered_data],
+                "total_pages": 1,
+                "current_page": 1,
+                "total_items": 1
+            }
+        else:
+            # This is just a way of saying such a question doesnt exits
+            return {"questions": [], "total_pages": 0, "current_page": 1, "total_items": 0}
+    
+    if topic and topic != "All":
+        topic = topic.strip().title()
+        query = query.where(filter=FieldFilter("topic", "==", topic))
+    if difficulty and difficulty != "All":
+        difficulty = difficulty.strip().title()
+        query = query.where(filter=FieldFilter("difficulty", "==", difficulty))
+
+    offset = (page - 1) * page_size
+    
+    paged_query = query.select(["question_id", "title", "topic", "difficulty"]) \
+                       .order_by("question_id") \
+                       .limit(page_size) \
+                       .offset(offset)
+
+    questions = []
+    for doc in paged_query.stream():
+        data = doc.to_dict()
+        data["question_id"] = str(data.get("question_id", ""))
+        questions.append(data)
+
+    count_query = query.count()
+    count_result = count_query.get()
+    total_items = count_result[0][0].value
+
+    return {
+        "questions": questions,
+        "total_pages": (total_items + page_size - 1) // page_size,
+        "current_page": page,
+        "total_items": total_items
+    }
+
+
+# --- USER ENDPOINTS ---
+
+# Get a random question ID based on a given topic and difficulty level
+@router.get("/", response_model=dict)
+async def read_questions(
+    topic: str, 
+    difficulty: str
+):
+    topic = topic.strip().title()
+    difficulty = difficulty.strip().title()
+    
+    questions_ref = db.collection("questions")
+    query = questions_ref.where(
+        filter=FieldFilter("topic", "==", topic)
+    ).where(
+        filter=FieldFilter("difficulty", "==", difficulty)
+    )
+
+    # fetch only the document IDs
+    docs = query.select([]).stream()
+    doc_ids = [doc.id for doc in docs]
+
+    if not doc_ids:
+        raise HTTPException(
+            status_code=404, 
+            detail=f"No questions found for {topic} with {difficulty} difficulty"
+        )
+
+    randomQuestion_id = random.choice(doc_ids)
+
+    return {"question_id": randomQuestion_id}
+
+# @router.get("/brew", status_code=418)
+# async def brew():
+#     return {"detail": "I'm a teapot! The requested entity body is short and stout. Tip me over and pour me out!"}
+
+# Get specific question by ID
+# This endpoint is expected to be used by question-history service to fetch question details for a given question_id.
+@router.get("/{question_id}", response_model=Question)
+async def read_question(question_id: str):
+    questions_ref = db.collection("questions")
+
+    # Fetch the question
+    doc_ref = questions_ref.document(question_id)
+    doc = doc_ref.get()
+
+    if not doc.exists:
+        raise HTTPException(
+            status_code=404, 
+            detail=f"Question not found with ID: {question_id}"
+        )
+
+    question_data = doc.to_dict()
+    
+    # Add the document ID to the returned data for consistency with the Question model
+    question_data["question_id"] = doc.id
+
+    return question_data

--- a/backend/question-service/app/models/domain.py
+++ b/backend/question-service/app/models/domain.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 from typing import Optional, List
 
 class QuestionBase(BaseModel):
@@ -30,6 +30,11 @@ class Question(QuestionBase):
 
     class Config:
         from_attributes = True
+
+    @field_validator('question_id', mode='before')
+    @classmethod
+    def transform_id_to_string(cls, v):
+        return str(v)
 
 class QuestionMetadata(BaseModel):
     question_id: str

--- a/backend/question-service/app/models/domain.py
+++ b/backend/question-service/app/models/domain.py
@@ -30,3 +30,18 @@ class Question(QuestionBase):
 
     class Config:
         from_attributes = True
+
+class QuestionMetadata(BaseModel):
+    question_id: str
+    title: str
+    topic: str
+    difficulty: str
+
+    class Config:
+        coerce_numbers_to_str = True
+
+class PaginatedQuestions(BaseModel):
+    questions: List[QuestionMetadata]
+    total_pages: int
+    current_page: int
+    total_items: int

--- a/frontend/src/components/AdminPage.tsx
+++ b/frontend/src/components/AdminPage.tsx
@@ -1,5 +1,15 @@
+/**
+ * AI USE DECLARATION:
+ * This page utilizes AI generated boilerplate for Tailwind CSS styling 
+ * and React state update patterns. Core business logic, API integration 
+ * sequences, and input validation rules were manually architected and 
+ * verified to ensure system integrity.
+ * All AI-generated snippets have been manually reviewed, refactored for 
+ * PeerPrep's specific architecture, and verified.
+ */
+
 import { useState, useEffect } from 'react';
-import { Shield, Trash2, Loader2, Star, Users, BookOpen, Plus, X, Search, Save, LogOut } from 'lucide-react';
+import { Shield, Trash2, Loader2, Star, Users, BookOpen, Plus, X, Search, Save, LogOut, ChevronRight } from 'lucide-react';
 import { GATEWAY_URL } from '../constants';
 import { DynamicArrayInput } from './ui/DynamicArrayInput';
 import { QuestionModal } from './ui/QuestionModal'
@@ -10,6 +20,7 @@ import 'katex/dist/katex.min.css';
 import CodeMirror from '@uiw/react-codemirror';
 import { python } from '@codemirror/lang-python';
 import { dracula } from '@uiw/codemirror-theme-dracula';
+import { useRef } from 'react';
 
 interface AdminPageProps {
   currentUser: any;
@@ -29,14 +40,63 @@ export function AdminPage({ currentUser, onLogout }: AdminPageProps) {
   // Question State
   const [searchId, setSearchId] = useState('');
   const [managedQuestion, setManagedQuestion] = useState<any>(null);
-  const [isAddingQuestion, setIsAddingQuestion] = useState(false);
-  
+  const [filterTopic, setFilterTopic] = useState('All');
+  const [filterDifficulty, setFilterDifficulty] = useState('All');
+  const [availableTopics, setAvailableTopics] = useState<string[]>([]);
+  const [availableDifficulties, setAvailableDifficulties] = useState<string[]>([]);
+  // const [isAddingQuestion, setIsAddingQuestion] = useState(false);
+
+  const [questions, setQuestions] = useState<any[]>([]);
+  const [currentPage, setCurrentPage] = useState(1);
+  const [totalPages, setTotalPages] = useState(1);
+  const questionsPerPage = 10;
+  const [activeSearchMode, setActiveSearchMode] = useState<'none' | 'id' | 'criteria'>('none');
+
+  const isFiltered =
+    activeSearchMode !== 'none' ||
+    searchId.trim() !== '' ||
+    filterTopic !== 'All' ||
+    filterDifficulty !== 'All';
+
   // New Question Form State
   const [modalConfig, setModalConfig] = useState<{
     isOpen: boolean;
     mode: 'add' | 'edit';
     data?: any;
   }>({ isOpen: false, mode: 'add' });
+
+  const fetchQuestions = async (page: number, topic = 'All', difficulty = 'All') => {
+    setIsLoading(true);
+    try {
+      const token = localStorage.getItem('peerprep_token');
+
+      let url = `${GATEWAY_URL}/question/all?page=${page}&limit=10`;
+      if (topic !== 'All') url += `&topic=${encodeURIComponent(topic)}`;
+      if (difficulty !== 'All') url += `&difficulty=${difficulty}`;
+
+      const response = await fetch(url, {
+        headers: { 'Authorization': `Bearer ${token}` }
+      });
+
+      const data = await response.json();
+      setQuestions(data.questions);
+      setTotalPages(data.total_pages);
+      setCurrentPage(data.current_page);
+    } catch (err: any) {
+      setError("Failed to filter questions");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  // Refetch whenever the page changes
+  useEffect(() => {
+    if (activeTab === 'questions') {
+      if (!searchId) {
+        fetchQuestions(currentPage, filterTopic, filterDifficulty);
+      }
+    }
+  }, [activeTab, currentPage]);
 
   useEffect(() => {
     if (activeTab === 'users') {
@@ -64,70 +124,177 @@ export function AdminPage({ currentUser, onLogout }: AdminPageProps) {
     }
   };
 
-  const handleModalSuccess = (updatedData?: any) => {
-    if (modalConfig.mode === 'edit' && updatedData) {
-      setManagedQuestion(updatedData);
+  const handleModalSuccess = async (updatedData?: any) => {
+  if (!updatedData) return;
+
+  if (modalConfig.mode === 'edit') {
+    // For Edits, we keep the search criteria because the admin 
+    // likely wants to stay in their filtered view. It may show some stale value 
+    // (ie. the new update might be out of place from the current search, 
+    // but it just brings more convinience for the admin to be in this way)
+    setManagedQuestion(updatedData);
+    setQuestions(prev =>
+      prev.map(q =>
+        q.question_id.toString() === updatedData.question_id.toString()
+          ? { ...q, title: updatedData.title, topic: updatedData.topic, difficulty: updatedData.difficulty }
+          : q
+      )
+    );
+  } else {
+    // For Adds, we reset the search state 
+    setSearchId('');
+    setFilterTopic('All');
+    setFilterDifficulty('All');
+    setActiveSearchMode('none'); 
+
+    if (currentPage === totalPages) {
+      await fetchQuestions(currentPage, 'All', 'All');
+    } else {
+      await fetchQuestions(1, 'All', 'All'); 
     }
-    // later if req, trigger fetchQuestions() over here
+    setManagedQuestion(updatedData);
+  }
+  await refreshMetadata();
+};
+
+  const fetchQuestionDetails = async (id: string) => {
+    setActionLoading(`fetching-${id}`);
+    try {
+      const token = localStorage.getItem('peerprep_token');
+      const response = await fetch(`${GATEWAY_URL}/question/${id}`, {
+        headers: { 'Authorization': `Bearer ${token}` }
+      });
+      if (!response.ok) throw new Error('Failed to fetch details');
+      const data = await response.json();
+      setManagedQuestion(data);
+    } catch (err: any) {
+      alert(err.message);
+    } finally {
+      setActionLoading(null);
+    }
   };
 
   const handleLookupQuestion = async (e?: React.FormEvent) => {
     if (e) e.preventDefault();
     if (!searchId.trim()) return;
 
-    // if (isEditing) {
-    //   const hasChanges = JSON.stringify(managedQuestion) !== JSON.stringify(backupQuestion);
-    //   if (hasChanges && !window.confirm("Discard changes to the current question and search for a new one?")) {
-    //     return;
-    //   }
-    // }
-
-    setActionLoading('lookup-q');
-    setError('');
+    // Clear Metadata Filters and previous managed question
+    setFilterTopic('All');
+    setFilterDifficulty('All');
     setManagedQuestion(null);
 
+    setActionLoading('lookup-q');
     try {
       const token = localStorage.getItem('peerprep_token');
       const response = await fetch(`${GATEWAY_URL}/question/${searchId}`, {
         headers: { 'Authorization': `Bearer ${token}` }
       });
-      
-      if (!response.ok) {
-        if (response.status === 404) throw new Error('Question not found');
-        throw new Error('Failed to fetch question');
-      }
 
+      if (!response.ok) throw new Error('Question not found');
       const data = await response.json();
       setManagedQuestion(data);
-      // setIsEditing(false);
-      // setBackupQuestion(null);
+      setQuestions([data]);
+      setTotalPages(1); 
+      setCurrentPage(1);
+      setActiveSearchMode('id');
     } catch (err: any) {
-      setError(err.message);
-      setManagedQuestion(null);
-      // setIsEditing(false);
+      alert(err.message);
     } finally {
       setActionLoading(null);
     }
   };
 
+  const handleMetadataSearch = () => {
+    // Clear ID Search and previous managed question
+    setSearchId('');
+    setManagedQuestion(null);
+
+    // Perform the fetch
+    fetchQuestions(1, filterTopic, filterDifficulty);
+    if (filterTopic === 'All' && filterDifficulty === 'All') {
+      setActiveSearchMode('none');
+    } else {
+      setActiveSearchMode('criteria');
+    }
+  };
+
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    // Only scroll if a question was actually expanded (managedQuestion is not null)
+    if (managedQuestion && scrollRef.current) {
+      scrollRef.current.scrollIntoView({
+        behavior: 'smooth',
+        block: 'start' // Aligns the top of the card to the top of the screen
+      });
+    }
+  }, [managedQuestion]);
+
   
-  const handleTabChange = (tab: AdminTab) => {
-    // if (isEditing) {
-    //   const hasChanges = JSON.stringify(managedQuestion) !== JSON.stringify(backupQuestion);
-    //   if (hasChanges && !window.confirm("You have unsaved changes. Discard them?")) {
-    //     return; // Stay on current tab
-    //   }
-    // }
-    // Reset states when moving away
-    
+
+  const fetchMetadata = async () => {
+    try {
+      const token = localStorage.getItem('peerprep_token');
+      const headers = { 'Authorization': `Bearer ${token}` };
+
+      const [topicsRes, diffRes] = await Promise.all([
+        fetch(`${GATEWAY_URL}/question/topics`, { headers }),
+        fetch(`${GATEWAY_URL}/question/difficulties`, { headers })
+      ]);
+
+      if (topicsRes.ok && diffRes.ok) {
+        const topics = await topicsRes.json();
+        const difficulties = await diffRes.json();
+        setAvailableTopics(topics);
+        setAvailableDifficulties(difficulties);
+      }
+    } catch (err) {
+      console.error("Metadata fetch failed", err);
+    }
+  };
+
+
+  useEffect(() => {
+    fetchMetadata();
+  }, []);
+
+  const refreshMetadata = async () => {
+    try {
+      const token = localStorage.getItem('peerprep_token');
+      const headers = { 'Authorization': `Bearer ${token}` };
+
+      const [topicsRes, diffRes] = await Promise.all([
+        fetch(`${GATEWAY_URL}/question/topics`, { headers }),
+        fetch(`${GATEWAY_URL}/question/difficulties`, { headers })
+      ]);
+
+      if (topicsRes.ok && diffRes.ok) {
+        setAvailableTopics(await topicsRes.json());
+        setAvailableDifficulties(await diffRes.json());
+      }
+    } catch (err) {
+      console.error("Metadata refresh failed", err);
+    }
+  };
+  
+  const handleTabChange = (tab: AdminTab) => {    
     setManagedQuestion(null); 
     setSearchId('');
     setActiveTab(tab);
   };
 
+  // Update your fetchQuestions call inside useEffect
+  useEffect(() => {
+    if (activeTab === 'questions') {
+      if (questions.length === 1 && totalPages === 1) return;
+      fetchQuestions(currentPage, filterTopic, filterDifficulty);
+    }
+  }, [activeTab, currentPage]); 
+
+
   const handleDeleteQuestion = async (questionId: string) => {
     if (!window.confirm('Are you sure you want to delete this question?')) return;
-    
+
     setActionLoading(`delete-q-${questionId}`);
     try {
       const token = localStorage.getItem('peerprep_token');
@@ -137,12 +304,23 @@ export function AdminPage({ currentUser, onLogout }: AdminPageProps) {
       });
 
       if (!response.ok) throw new Error('Failed to delete question');
-      
-      if (managedQuestion?.question_id === questionId) {
+
+      const updatedQuestions = questions.filter(q => q.question_id.toString() !== questionId.toString());
+      setQuestions(updatedQuestions);
+
+      if (managedQuestion?.question_id.toString() === questionId.toString()) {
         setManagedQuestion(null);
-        setSearchId('');
       }
+
+      // Logic for jumping back a page if the current one becomes empty
+      if (updatedQuestions.length === 0 && currentPage > 1) {
+        setCurrentPage(prev => prev - 1);
+      } else if (updatedQuestions.length === 0 && currentPage === 1) {
+        fetchQuestions(1);
+      }
+
       alert('Question deleted successfully');
+      await refreshMetadata(); // Refresh after successful delete
     } catch (err: any) {
       alert(err.message);
     } finally {
@@ -194,22 +372,6 @@ export function AdminPage({ currentUser, onLogout }: AdminPageProps) {
       setActionLoading(null);
     }
   };
-
-
-
-  // Handle the case for unsaved changes when user tries to close the tab or navigate away through browser controls
-  // useEffect(() => {
-  //   const handleBeforeUnload = (e: BeforeUnloadEvent) => {
-  //     const hasChanges = isEditing && JSON.stringify(managedQuestion) !== JSON.stringify(backupQuestion);
-  //     if (hasChanges) {
-  //       e.preventDefault();
-  //       e.returnValue = ''; 
-  //     }
-  //   };
-
-  //   window.addEventListener('beforeunload', handleBeforeUnload);
-  //   return () => window.removeEventListener('beforeunload', handleBeforeUnload);
-  // }, [isEditing, managedQuestion, backupQuestion]);
 
   return (
     <div className="min-h-screen p-6 bg-[#2D2942]">
@@ -316,7 +478,7 @@ export function AdminPage({ currentUser, onLogout }: AdminPageProps) {
           ) : (
             <>
               <div className="flex justify-between items-center mb-6">
-                <h2 className="text-white font-bold text-2xl">Question Management</h2>
+                <h2 className="text-white font-bold text-2xl">Question Bank</h2>
                 <button 
                   onClick={() => setModalConfig({ isOpen: true, mode: 'add' })}
                   className="btn-secondary py-2 px-4 flex items-center gap-2"
@@ -325,301 +487,250 @@ export function AdminPage({ currentUser, onLogout }: AdminPageProps) {
                   Add New
                 </button>
               </div>
+                <div className="space-y-3 mb-8">
+                  {/* Choice 1: Search by ID */}
+                  <div className="space-y-3">
+                    <form onSubmit={handleLookupQuestion} className="flex gap-3">
+                      <div className="relative flex-1">
+                        <Search className="absolute left-4 top-1/2 -translate-y-1/2 w-5 h-5 text-gray-400" />
+                        <input
+                          type="text"
+                          placeholder="Enter Question ID..."
+                          value={searchId}
+                          onChange={(e) => setSearchId(e.target.value)}
+                          className="input-field w-full pl-12"
+                        />
+                      </div>
+                      <button type="submit" className="btn-primary px-8">Search ID</button>
+                    </form>
+                  </div>
 
-              {/* Lookup Form */}
-              <form onSubmit={handleLookupQuestion} className="flex gap-3 mb-8">
-                <div className="relative flex-1">
-                  <Search className="absolute left-4 top-1/2 transform -translate-y-1/2 w-5 h-5 text-gray-400" />
-                  <input
-                    type="text"
-                    placeholder="Enter Question ID (e.g., 1)"
-                    value={searchId}
-                    onChange={(e) => setSearchId(e.target.value)}
-                    className="input-field w-full pl-12"
-                  />
-                </div>
-                <button 
-                  type="submit" 
-                  disabled={actionLoading === 'lookup-q'}
-                  className="btn-primary flex items-center gap-2 whitespace-nowrap"
-                >
-                  {actionLoading === 'lookup-q' ? <Loader2 className="w-5 h-5 animate-spin" /> : <Search className="w-5 h-5" />}
-                  Find Question
-                </button>
-              </form>
+                  {/*  Separator */}
+                  <div className="relative flex items-center py-1">
+                    <div className="flex-grow h-px bg-gradient-to-r from-transparent via-white/10 to-transparent"></div>
+                    <span className="flex-none mx-4 text-gray-500 font-bold italic text-[12px] uppercase tracking-[0.3em]">
+                      or
+                    </span>
+                    <div className="flex-grow h-px bg-gradient-to-r from-transparent via-white/10 to-transparent"></div>
+                  </div>
 
-              {/* Managed Question Details */}
-              {managedQuestion && (
-                <div className="bg-[#3A3552] rounded-[32px] p-8 space-y-8 border-2 border-[#E8B995]/20 animate-in fade-in slide-in-from-bottom-4">
-                  
-                  <div className="flex justify-between items-start">
-                    <div>
-                      <h3 className="text-white font-bold text-xl">Question #{managedQuestion.question_id}</h3>
-                    </div>
-                    <div className="flex gap-2">
-                      <button 
-                        onClick={() => setModalConfig({ isOpen: true, mode: 'edit', data: managedQuestion })} 
-                        className="btn-secondary py-1.5 px-4 text-sm flex items-center gap-2"
+                  {/* Choice 2: Search by Topic/Difficulty */}
+                  <div className="space-y-3">
+                    <div className="flex flex-wrap gap-3">
+                      <select
+                        value={filterTopic}
+                        onChange={(e) => setFilterTopic(e.target.value)}
+                        className="input-field flex-1 bg-[#3A3552] cursor-pointer"
                       >
-                        <Plus className="w-4 h-4 rotate-45" /> Edit Question
-                      </button>
-                      <button onClick={() => handleDeleteQuestion(managedQuestion.question_id)} className="text-red-500 hover:bg-red-500/10 p-2 rounded-full transition-colors">
-                        <Trash2 className="w-5 h-5" />
-                      </button>
-                    </div>
-                  </div>
+                        <option value="All">Any Topic</option>
+                        {availableTopics.map(t => <option key={t} value={t}>{t}</option>)}
+                      </select>
 
-                  <div className="grid md:grid-cols-2 gap-6">
-                    <div className="space-y-2">
-                      <label className="text-gray-400 text-xs font-bold uppercase tracking-wider ml-2">Title</label>
-                      <input 
-                        disabled={true}
-                        value={managedQuestion.title}
-                        onChange={(e) => setManagedQuestion({...managedQuestion, title: e.target.value})}
-                        className={`input-field w-full bg-[#2D2942]`}
-                      />
-                    </div>
-                    <div className="space-y-2">
-                      <label className="text-gray-400 text-xs font-bold uppercase tracking-wider ml-2">Topic</label>
-                      
-                        <div className="input-field w-full bg-[#2D2942] opacity-70 border-transparent">{managedQuestion.topic}</div>
-                      
-                    </div>
-                  </div>
+                      <select
+                        value={filterDifficulty}
+                        onChange={(e) => setFilterDifficulty(e.target.value)}
+                        className="input-field flex-1 bg-[#3A3552] cursor-pointer"
+                      >
+                        <option value="All">Any Difficulty</option>
+                        {availableDifficulties.map(d => <option key={d} value={d}>{d}</option>)}
+                      </select>
 
-                  <div className="space-y-2">
-                    <label className="text-gray-400 text-xs font-bold uppercase tracking-wider ml-2">
-                      Difficulty
-                    </label>
-                    <div className={`flex gap-3`}>
-                      {['Easy', 'Medium', 'Hard'].map((diff) => (
+                      <button
+                        onClick={handleMetadataSearch}
+                        className="btn-secondary px-8 flex items-center gap-2"
+                      >
+                        <Search className="w-4 h-4" /> Search by Criteria
+                      </button>
+
+                      {/* Global Clear Search */}
+                      
                         <button
-                          key={diff}
-                          type="button"
-                          // onClick={() => setManagedQuestion({ ...managedQuestion, difficulty: diff })}
-                          className={`flex-1 py-2.5 rounded-xl font-bold transition-all text-sm ${
-                            managedQuestion.difficulty === diff 
-                              ? 'bg-[#E8B995] text-[#4A4563]' 
-                              : 'bg-[#2D2942] text-white opacity-40'
-                          }`}
+                          disabled={!isFiltered}
+                          onClick={() => {
+                            setFilterTopic('All');
+                            setFilterDifficulty('All');
+                            setSearchId('');
+                            setManagedQuestion(null);
+                            setActiveSearchMode('none');
+                            setCurrentPage(1);
+                            fetchQuestions(1, 'All', 'All');
+                          }}
+                          className="text-gray-400 hover:text-white px-4 flex items-center gap-2 transition-colors border border-white/5 rounded-xl hover:bg-white/5"
                         >
-                          {diff}
+                          <X className="w-4 h-4" /> Reset All
                         </button>
-                      ))}
+                      
                     </div>
                   </div>
+                </div>
 
-                  {/* Problem Statement */}
-                  <div className="space-y-2">
-                    <label className="text-gray-400 text-xs font-bold uppercase tracking-wider ml-2">Problem Statement</label>
+
+              {/* The Expandable List */}
+              <div className="space-y-4">
+                {isLoading ? (
+                  <div className="flex justify-center py-12"><Loader2 className="animate-spin text-[#E8B995]" /></div>
+                ) : questions.length === 0 ? (
+                  <p className="text-gray-400 text-center py-8">No questions found on this page.</p>
+                ) : (
+                  questions.map((q) => {
+                    const isExpanded = managedQuestion?.question_id?.toString() === q.question_id.toString();
                     
-                      <div className="prose prose-invert max-w-none text-white bg-[#2D2942]/50 p-6 rounded-[24px] border border-white/5">
-                        <ReactMarkdown 
-                          remarkPlugins={[remarkMath]} 
-                          rehypePlugins={[rehypeKatex]}
-                          components={{
-                            ol: ({node, ...props}) => <ol className="list-decimal pl-8 mb-4 space-y-2 text-white" {...props} />,
-                            ul: ({node, ...props}) => <ul className="list-disc pl-8 mb-4 space-y-2 text-white" {...props} />,
-                            li: ({node, ...props}) => <li className="text-white leading-relaxed" {...props} />,
-                            p: ({node, ...props}) => <p className="mb-4 last:mb-0 leading-relaxed break-words whitespace-pre-wrap" {...props} />
+                    return (
+                      <div
+                        key={q.question_id}
+                        className={`transition-all duration-300 rounded-[24px] overflow-hidden border-2 ${isExpanded ? 'bg-[#3A3552] border-[#E8B995] shadow-xl' : 'bg-[#3A3552]/40 border-transparent hover:border-white/10'
+                          }`}
+                      >
+                        {/* The main clickable header area */}
+                        
+                        <div
+                          ref={isExpanded ? scrollRef : null}
+                          style={{ scrollMarginTop: '20px' }}
+                          className="p-5 flex items-center justify-between cursor-pointer group"
+                          onClick={() => {
+                            // If we only have 1 question in the list, we are in "Search Mode"
+                            // Prevent collapsing in this mode
+                            const isSearchMode = questions.length === 1 && searchId !== '';
+
+                            if (isExpanded) {
+                              if (!isSearchMode) {
+                                setManagedQuestion(null);
+                              }
+                              // If isSearchMode, we do nothing (keep it expanded)
+                            } else {
+                              fetchQuestionDetails(q.question_id.toString());
+                            }
                           }}
                         >
-                          {managedQuestion.statement}
-                        </ReactMarkdown>
+                          {/* LEFT SIDE INFO (Now inside the clickable div) */}
+                          <div className="flex items-center gap-4">
+                            <span className="text-[#E8B995] font-mono font-bold">#{q.question_id}</span>
+                            <div>
+                              <h4 className="text-white font-bold group-hover:text-[#E8B995] transition-colors">{q.title}</h4>
+                              <div className="flex gap-2 mt-1">
+                                <span className="text-[10px] uppercase font-bold text-gray-400">{q.topic}</span>
+                                <span className={`text-[10px] uppercase font-bold ${q.difficulty === 'Easy' ? 'text-green-400' :
+                                    q.difficulty === 'Medium' ? 'text-yellow-400' : 'text-red-400'
+                                  }`}>• {q.difficulty}</span>
+                              </div>
+                            </div>
+                          </div>
+
+                          {/* RIGHT SIDE ICONS */}
+                          <div className="flex items-center gap-3">
+                            {/* Update the loading check to use the specific ID */}
+                            {actionLoading === `fetching-${q.question_id}` && (
+                              <Loader2 className="w-4 h-4 animate-spin text-[#E8B995]" />
+                            )}
+                            <ChevronRight className={`... ${isExpanded ? 'rotate-90' : ''}`} />
+                          </div>
+                        </div>
+
+                        {/* Expandable Content (The "Deep" View) */}
+                        {isExpanded && (
+                          <div className="p-8 pt-0 space-y-8 animate-in fade-in slide-in-from-top-4">
+                            <div className="h-px bg-white/5 w-full mb-6" />
+                            
+                            {/* Reuse your existing Managed Question UI here */}
+                            <div className="flex justify-end gap-2">
+                              <button 
+                                onClick={() => setModalConfig({ isOpen: true, mode: 'edit', data: managedQuestion })} 
+                                className="btn-secondary py-1.5 px-4 text-sm flex items-center gap-2"
+                              >
+                                <Plus className="w-4 h-4 rotate-45" /> Edit Question
+                              </button>
+                              <button onClick={() => handleDeleteQuestion(managedQuestion.question_id)} className="text-red-500 hover:bg-red-500/10 p-2 rounded-full transition-colors">
+                                <Trash2 className="w-5 h-5" />
+                              </button>
+                            </div>
+
+                            <div className="space-y-2">
+                              <label className="text-gray-400 text-xs font-bold uppercase tracking-wider">Problem Statement</label>
+                              <div className="prose prose-invert max-w-none text-white bg-[#2D2942]/50 p-6 rounded-[20px] border border-white/5">
+                                <ReactMarkdown remarkPlugins={[remarkMath]} rehypePlugins={[rehypeKatex]}>
+                                  {managedQuestion.statement}
+                                </ReactMarkdown>
+                              </div>
+                            </div>
+
+                            <div className="space-y-6">
+                              <DynamicArrayInput 
+                                label="Examples" 
+                                items={managedQuestion.examples?.filter((e: string) => e.trim() !== '') || []}
+                                isEditing={false}
+                                emptyMessage="No examples provided."
+                              />
+                              <DynamicArrayInput 
+                                label="Constraints" 
+                                items={managedQuestion.constraints?.filter((c: string) => c.trim() !== '') || []}
+                                isEditing={false}
+                                emptyMessage="No constraints defined."
+                              />
+                              <DynamicArrayInput 
+                                label="Hints"
+                                items={managedQuestion.hints?.filter((h: string) => h.trim() !== '') || []}
+                                isEditing={false}
+                                emptyMessage="No hints available for this question."
+                              />
+                            </div>
+
+                            <div className="space-y-2">
+                              <label className="text-gray-400 text-xs font-bold uppercase tracking-wider">Python Template</label>
+                              <div className="rounded-[20px] overflow-hidden border border-white/5">
+                                <CodeMirror value={managedQuestion.template} theme={dracula} extensions={[python()]} readOnly={true} />
+                              </div>
+                            </div>
+                          </div>
+                        )}
                       </div>
-                    
-                  </div>
+                    );
+                  })
+                )}
+              </div>
 
-                  <div className="space-y-10">
-  
-                    <DynamicArrayInput 
-                      label="Examples" 
-                      items={managedQuestion.examples?.filter((e: string) => e.trim() !== '') || []}
-                      isEditing={false}
-                      minRows={4}
-                      emptyMessage="No examples provided for this question."
-                    />
+              {/* Pagination Controls moved below the list */}
+              <div className="flex items-center justify-center gap-4 mt-12 pb-8">
+                <div className="flex items-center justify-center gap-4 mt-8">
+                <button
+                  disabled={currentPage === 1}
+                  onClick={() => setCurrentPage(prev => prev - 1)}
+                  className="px-4 py-2 rounded-xl bg-[#3A3552] text-white disabled:opacity-30 hover:bg-[#453F5C] transition-all"
+                >
+                  Previous
+                </button>
 
-                    <DynamicArrayInput 
-                      label="Constraints" 
-                      items={managedQuestion.constraints?.filter((c: string) => c.trim() !== '') || []}
-                      isEditing={false}
-                      minRows={2}
-                      emptyMessage="No specific constraints defined."
-                    />
-
-                    <DynamicArrayInput 
-                      label="Hints" 
-                      items={managedQuestion.hints?.filter((h: string) => h.trim() !== '') || []}
-                      isEditing={false}
-                      minRows={2}
-                      emptyMessage="No hints available."
-                    />
-                  </div>
-
-                  {/* Code Template */}
-                  <div className="space-y-2">
-                    <label className="text-gray-400 text-xs font-bold uppercase tracking-wider ml-2">Python Code Template</label>
-                    <div className={`rounded-[24px] overflow-hidden border-2 transition-all border-white/5`}>
-                      <CodeMirror
-                        value={managedQuestion.template}
-                        minHeight="150px"
-                        theme={dracula}
-                        extensions={[python()]}
-                        readOnly={true}
-                        onChange={(value) => setManagedQuestion({ ...managedQuestion, template: value })}
-                      />
-                    </div>
-                  </div>
-
-                  {/* {isEditing && (
-                    <button 
-                      onClick={handleUpdateQuestion}
-                      disabled={actionLoading === 'update-q'}
-                      className="w-full btn-secondary flex items-center justify-center gap-2 py-4 text-lg"
-                    >
-                      {actionLoading === 'update-q' ? <Loader2 className="w-5 h-5 animate-spin" /> : <Save className="w-5 h-5" />}
-                      Save Changes
-                    </button>
-                  )} */}
+                <div className="flex gap-2">
+                  {Array.from({ length: totalPages }).map((_, i) => {
+                    const pageNum = i + 1;
+                    return (
+                      <button
+                        key={pageNum}
+                        onClick={() => setCurrentPage(pageNum)}
+                        className={`w-10 h-10 rounded-xl font-bold transition-all ${
+                          currentPage === pageNum 
+                            ? 'bg-[#E8B995] text-[#4A4563] shadow-lg shadow-[#E8B995]/20' 
+                            : 'bg-[#3A3552] text-white hover:bg-[#453F5C]'
+                        }`}
+                      >
+                        {pageNum}
+                      </button>
+                    );
+                  })}
                 </div>
-              )}
+
+                <button
+                  disabled={currentPage === totalPages}
+                  onClick={() => setCurrentPage(prev => prev + 1)}
+                  className="px-4 py-2 rounded-xl bg-[#3A3552] text-white disabled:opacity-30 hover:bg-[#453F5C] transition-all"
+                >
+                  Next
+                </button>
+              </div>
+              </div>
             </>
           )}
         </div>
       </div>
-
-      {/* Add Question Modal (Remains similar but with direct creation) */}
-      {/* {isAddingQuestion && (
-        <div className="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center p-6 z-50">
-          <div className="bg-[#4A4563] rounded-[32px] w-full max-w-2xl max-h-[90vh] overflow-y-auto p-8 relative custom-scrollbar">
-            <button 
-              onClick={() => setIsAddingQuestion(false)}
-              className="absolute top-6 right-6 text-gray-400 hover:text-white"
-            >
-              <X className="w-6 h-6" />
-            </button>
-            
-            <h2 className="text-white font-bold text-2xl mb-6">New Question</h2>
-            
-            <form onSubmit={handleAddQuestion} className="space-y-6">
-              <div className="grid md:grid-cols-2 gap-4">
-                <div className="space-y-2">
-                  <label className="text-gray-300 text-sm ml-2">Title</label>
-                  <input 
-                    required
-                    value={newQuestion.title}
-                    onChange={(e) => setNewQuestion({...newQuestion, title: e.target.value})}
-                    placeholder="e.g. Two Sum"
-                    className="input-field w-full"
-                  />
-                </div>
-                <div className="space-y-2">
-                  <label className="text-gray-300 text-sm ml-2">Topic</label>
-                  <select 
-                    value={newQuestion.topic}
-                    onChange={(e) => setNewQuestion({...newQuestion, topic: e.target.value})}
-                    className="input-field w-full appearance-none"
-                  >
-                    <option>Arrays</option>
-                    <option>Strings</option>
-                    <option>Hash Tables</option>
-                    <option>Linked Lists</option>
-                    <option>Trees</option>
-                    <option>Graphs</option>
-                    <option>Greedy</option>
-                    <option>Dynamic Programming</option>
-                  </select>
-                </div>
-              </div>
-
-              <div className="space-y-2">
-                <label className="text-gray-300 text-sm ml-2">Difficulty</label>
-                <div className="flex gap-4">
-                  {['Easy', 'Medium', 'Hard'].map((diff) => (
-                    <button
-                      key={diff}
-                      type="button"
-                      onClick={() => setNewQuestion({...newQuestion, difficulty: diff})}
-                      className={`flex-1 py-3 rounded-2xl font-bold transition-all ${
-                        newQuestion.difficulty === diff 
-                        ? 'bg-[#E8B995] text-[#4A4563]' 
-                        : 'bg-[#3A3552] text-white hover:bg-[#453F5C]'
-                      }`}
-                    >
-                      {diff}
-                    </button>
-                  ))}
-                </div>
-              </div>
-
-              <div className="space-y-2">
-                <label className="text-gray-300 text-sm ml-2">Problem Statement</label>
-                <textarea 
-                  required
-                  rows={4}
-                  value={newQuestion.statement}
-                  onChange={(e) => setNewQuestion({...newQuestion, statement: e.target.value})}
-                  placeholder="Describe the problem (in MarkDown)..."
-                  className="input-field w-full rounded-[24px] resize-none"
-                />
-              </div>
-
-              <div className="space-y-2">
-                <label className="text-gray-400 text-sm ml-2">Python Code Template</label>
-                <div className="rounded-[24px] overflow-hidden transition-all border-[#E8B995]">
-                  <CodeMirror
-                    value={newQuestion.template}
-                    minHeight="150px"
-                    maxHeight="200px"
-                    theme={dracula}
-                    extensions={[python()]}
-                    readOnly={false}
-                    editable={true}
-                    basicSetup={{
-                      lineNumbers: true,
-                      indentOnInput: true,
-                    }}
-                    onChange={(value) => setNewQuestion({ ...newQuestion, template: value })}
-                  />
-                </div>
-              </div>
-
-              <div className="space-y-8">
-                <DynamicArrayInput 
-                  label="Examples" 
-                  items={newQuestion.examples} 
-                  minRows={4} 
-                  onUpdate={(val: string[]) => setNewQuestion({...newQuestion, examples: val})} 
-                />
-
-                <DynamicArrayInput 
-                  label="Constraints" 
-                  items={newQuestion.constraints} 
-                  minRows={2} 
-                  onUpdate={(val: string[]) => setNewQuestion({...newQuestion, constraints: val})} 
-                />
-
-                <DynamicArrayInput 
-                  label="Hints" 
-                  items={newQuestion.hints} 
-                  minRows={2} 
-                  onUpdate={(val: string[]) => setNewQuestion({...newQuestion, hints: val})} 
-                />
-              </div>
-
-              <button 
-                type="submit" 
-                disabled={actionLoading === 'add-question'}
-                className="w-full btn-secondary text-lg py-4 flex items-center justify-center gap-2"
-              >
-                {actionLoading === 'add-question' ? <Loader2 className="w-5 h-5 animate-spin" /> : <Plus className="w-5 h-5" />}
-                Create Question
-              </button>
-            </form>
-          </div>
-        </div>
-      )} */}
 
       <QuestionModal 
         isOpen={modalConfig.isOpen}
@@ -627,6 +738,8 @@ export function AdminPage({ currentUser, onLogout }: AdminPageProps) {
         initialData={modalConfig.data}
         onClose={() => setModalConfig({ ...modalConfig, isOpen: false })}
         onSuccess={handleModalSuccess}
+        topics={availableTopics}
+        difficulties={availableDifficulties}
       />
 
       <style>{`

--- a/frontend/src/components/AdminPage.tsx
+++ b/frontend/src/components/AdminPage.tsx
@@ -396,7 +396,7 @@ export function AdminPage({ currentUser, onLogout }: AdminPageProps) {
                         <button
                           key={diff}
                           type="button"
-                          onClick={() => setManagedQuestion({ ...managedQuestion, difficulty: diff })}
+                          // onClick={() => setManagedQuestion({ ...managedQuestion, difficulty: diff })}
                           className={`flex-1 py-2.5 rounded-xl font-bold transition-all text-sm ${
                             managedQuestion.difficulty === diff 
                               ? 'bg-[#E8B995] text-[#4A4563]' 

--- a/frontend/src/components/AdminPage.tsx
+++ b/frontend/src/components/AdminPage.tsx
@@ -434,26 +434,26 @@ export function AdminPage({ currentUser, onLogout }: AdminPageProps) {
   
                     <DynamicArrayInput 
                       label="Examples" 
-                      items={managedQuestion.examples || ['']} 
+                      items={managedQuestion.examples?.filter((e: string) => e.trim() !== '') || []}
                       isEditing={false}
                       minRows={4}
-                      onUpdate={(val: string[]) => setManagedQuestion({...managedQuestion, examples: val})} 
+                      emptyMessage="No examples provided for this question."
                     />
 
                     <DynamicArrayInput 
                       label="Constraints" 
-                      items={managedQuestion.constraints || ['']} 
+                      items={managedQuestion.constraints?.filter((c: string) => c.trim() !== '') || []}
                       isEditing={false}
                       minRows={2}
-                      onUpdate={(val: string[]) => setManagedQuestion({...managedQuestion, constraints: val})} 
+                      emptyMessage="No specific constraints defined."
                     />
 
                     <DynamicArrayInput 
                       label="Hints" 
-                      items={managedQuestion.hints || ['']} 
+                      items={managedQuestion.hints?.filter((h: string) => h.trim() !== '') || []}
                       isEditing={false}
                       minRows={2}
-                      onUpdate={(val: string[]) => setManagedQuestion({...managedQuestion, hints: val})} 
+                      emptyMessage="No hints available."
                     />
                   </div>
 

--- a/frontend/src/components/AdminPage.tsx
+++ b/frontend/src/components/AdminPage.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { Shield, Trash2, Loader2, Star, Users, BookOpen, Plus, X, Search, Save, LogOut } from 'lucide-react';
 import { GATEWAY_URL } from '../constants';
 import { DynamicArrayInput } from './ui/DynamicArrayInput';
+import { QuestionModal } from './ui/QuestionModal'
 import ReactMarkdown from 'react-markdown';
 import remarkMath from 'remark-math';
 import rehypeKatex from 'rehype-katex';
@@ -24,9 +25,6 @@ export function AdminPage({ currentUser, onLogout }: AdminPageProps) {
   const [actionLoading, setActionLoading] = useState<string | null>(null);
   const [error, setError] = useState('');
   
-  // Question Management State
-  const [isEditing, setIsEditing] = useState(false); 
-  const [backupQuestion, setBackupQuestion] = useState<any>(null);
 
   // Question State
   const [searchId, setSearchId] = useState('');
@@ -34,16 +32,11 @@ export function AdminPage({ currentUser, onLogout }: AdminPageProps) {
   const [isAddingQuestion, setIsAddingQuestion] = useState(false);
   
   // New Question Form State
-  const [newQuestion, setNewQuestion] = useState({
-    title: '',
-    topic: 'Arrays',
-    difficulty: 'Easy',
-    statement: '',
-    template: '',
-    examples: [''],
-    constraints: [''],
-    hints: ['']
-  });
+  const [modalConfig, setModalConfig] = useState<{
+    isOpen: boolean;
+    mode: 'add' | 'edit';
+    data?: any;
+  }>({ isOpen: false, mode: 'add' });
 
   useEffect(() => {
     if (activeTab === 'users') {
@@ -71,16 +64,23 @@ export function AdminPage({ currentUser, onLogout }: AdminPageProps) {
     }
   };
 
+  const handleModalSuccess = (updatedData?: any) => {
+    if (modalConfig.mode === 'edit' && updatedData) {
+      setManagedQuestion(updatedData);
+    }
+    // later if req, trigger fetchQuestions() over here
+  };
+
   const handleLookupQuestion = async (e?: React.FormEvent) => {
     if (e) e.preventDefault();
     if (!searchId.trim()) return;
 
-    if (isEditing) {
-      const hasChanges = JSON.stringify(managedQuestion) !== JSON.stringify(backupQuestion);
-      if (hasChanges && !window.confirm("Discard changes to the current question and search for a new one?")) {
-        return;
-      }
-    }
+    // if (isEditing) {
+    //   const hasChanges = JSON.stringify(managedQuestion) !== JSON.stringify(backupQuestion);
+    //   if (hasChanges && !window.confirm("Discard changes to the current question and search for a new one?")) {
+    //     return;
+    //   }
+    // }
 
     setActionLoading('lookup-q');
     setError('');
@@ -99,69 +99,27 @@ export function AdminPage({ currentUser, onLogout }: AdminPageProps) {
 
       const data = await response.json();
       setManagedQuestion(data);
-      setIsEditing(false);
-      setBackupQuestion(null);
+      // setIsEditing(false);
+      // setBackupQuestion(null);
     } catch (err: any) {
       setError(err.message);
       setManagedQuestion(null);
-      setIsEditing(false);
+      // setIsEditing(false);
     } finally {
       setActionLoading(null);
     }
   };
 
-  const handleStartEditing = () => {
-    setBackupQuestion({ ...managedQuestion }); // Clone current state
-    setIsEditing(true);
-  };
-
-  const handleCancelEditing = () => {
-    // Check if anything actually changed before asking
-    const hasChanges = JSON.stringify(managedQuestion) !== JSON.stringify(backupQuestion);
-    
-    if (hasChanges) {
-      if (window.confirm("You have unsaved changes. Are you sure you want to discard them?")) {
-        setManagedQuestion(backupQuestion);
-        setIsEditing(false);
-      }
-    } else {
-      setIsEditing(false);
-    }
-  };
-
-  const handleUpdateQuestion = async () => {
-    if (!managedQuestion) return;
-    setActionLoading('update-q');
-    try {
-      const token = localStorage.getItem('peerprep_token');
-      const response = await fetch(`${GATEWAY_URL}/question/${managedQuestion.question_id}`, {
-        method: 'PUT',
-        headers: { 
-          'Authorization': `Bearer ${token}`,
-          'Content-Type': 'application/json'
-        },
-        body: JSON.stringify(managedQuestion)
-      });
-
-      if (!response.ok) throw new Error('Failed to update question');
-      
-      alert('Question updated successfully!');
-      setIsEditing(false); // Return to preview mode
-    } catch (err: any) {
-      alert(err.message);
-    } finally {
-      setActionLoading(null);
-    }
-  };
+  
   const handleTabChange = (tab: AdminTab) => {
-    if (isEditing) {
-      const hasChanges = JSON.stringify(managedQuestion) !== JSON.stringify(backupQuestion);
-      if (hasChanges && !window.confirm("You have unsaved changes. Discard them?")) {
-        return; // Stay on current tab
-      }
-    }
+    // if (isEditing) {
+    //   const hasChanges = JSON.stringify(managedQuestion) !== JSON.stringify(backupQuestion);
+    //   if (hasChanges && !window.confirm("You have unsaved changes. Discard them?")) {
+    //     return; // Stay on current tab
+    //   }
+    // }
     // Reset states when moving away
-    setIsEditing(false);
+    
     setManagedQuestion(null); 
     setSearchId('');
     setActiveTab(tab);
@@ -237,49 +195,21 @@ export function AdminPage({ currentUser, onLogout }: AdminPageProps) {
     }
   };
 
-  const handleAddQuestion = async (e: React.FormEvent) => {
-    e.preventDefault();
-    setActionLoading('add-question');
-    try {
-      const token = localStorage.getItem('peerprep_token');
-      const response = await fetch(`${GATEWAY_URL}/question/`, {
-        method: 'POST',
-        headers: { 
-          'Authorization': `Bearer ${token}`,
-          'Content-Type': 'application/json'
-        },
-        body: JSON.stringify(newQuestion)
-      });
 
-      if (!response.ok) throw new Error('Failed to add question');
-      
-      setIsAddingQuestion(false);
-      setNewQuestion({
-        title: '', topic: 'Arrays', difficulty: 'Easy',
-        statement: '', template: '', examples: [''],
-        constraints: [''], hints: ['']
-      });
-      alert('Question added successfully!');
-    } catch (err: any) {
-      alert(err.message);
-    } finally {
-      setActionLoading(null);
-    }
-  };
 
   // Handle the case for unsaved changes when user tries to close the tab or navigate away through browser controls
-  useEffect(() => {
-    const handleBeforeUnload = (e: BeforeUnloadEvent) => {
-      const hasChanges = isEditing && JSON.stringify(managedQuestion) !== JSON.stringify(backupQuestion);
-      if (hasChanges) {
-        e.preventDefault();
-        e.returnValue = ''; 
-      }
-    };
+  // useEffect(() => {
+  //   const handleBeforeUnload = (e: BeforeUnloadEvent) => {
+  //     const hasChanges = isEditing && JSON.stringify(managedQuestion) !== JSON.stringify(backupQuestion);
+  //     if (hasChanges) {
+  //       e.preventDefault();
+  //       e.returnValue = ''; 
+  //     }
+  //   };
 
-    window.addEventListener('beforeunload', handleBeforeUnload);
-    return () => window.removeEventListener('beforeunload', handleBeforeUnload);
-  }, [isEditing, managedQuestion, backupQuestion]);
+  //   window.addEventListener('beforeunload', handleBeforeUnload);
+  //   return () => window.removeEventListener('beforeunload', handleBeforeUnload);
+  // }, [isEditing, managedQuestion, backupQuestion]);
 
   return (
     <div className="min-h-screen p-6 bg-[#2D2942]">
@@ -388,7 +318,7 @@ export function AdminPage({ currentUser, onLogout }: AdminPageProps) {
               <div className="flex justify-between items-center mb-6">
                 <h2 className="text-white font-bold text-2xl">Question Management</h2>
                 <button 
-                  onClick={() => setIsAddingQuestion(true)}
+                  onClick={() => setModalConfig({ isOpen: true, mode: 'add' })}
                   className="btn-secondary py-2 px-4 flex items-center gap-2"
                 >
                   <Plus className="w-5 h-5" />
@@ -427,15 +357,12 @@ export function AdminPage({ currentUser, onLogout }: AdminPageProps) {
                       <h3 className="text-white font-bold text-xl">Question #{managedQuestion.question_id}</h3>
                     </div>
                     <div className="flex gap-2">
-                      {!isEditing ? (
-                        <button onClick={handleStartEditing} className="btn-secondary py-1.5 px-4 text-sm flex items-center gap-2">
-                          <Plus className="w-4 h-4 rotate-45" /> Edit Question
-                        </button>
-                      ) : (
-                        <button onClick={handleCancelEditing} className="bg-gray-500/20 text-gray-300 hover:bg-gray-500/40 py-1.5 px-4 rounded-xl text-sm font-bold transition-all">
-                          Discard Changes
-                        </button>
-                      )}
+                      <button 
+                        onClick={() => setModalConfig({ isOpen: true, mode: 'edit', data: managedQuestion })} 
+                        className="btn-secondary py-1.5 px-4 text-sm flex items-center gap-2"
+                      >
+                        <Plus className="w-4 h-4 rotate-45" /> Edit Question
+                      </button>
                       <button onClick={() => handleDeleteQuestion(managedQuestion.question_id)} className="text-red-500 hover:bg-red-500/10 p-2 rounded-full transition-colors">
                         <Trash2 className="w-5 h-5" />
                       </button>
@@ -446,32 +373,17 @@ export function AdminPage({ currentUser, onLogout }: AdminPageProps) {
                     <div className="space-y-2">
                       <label className="text-gray-400 text-xs font-bold uppercase tracking-wider ml-2">Title</label>
                       <input 
-                        disabled={!isEditing}
+                        disabled={true}
                         value={managedQuestion.title}
                         onChange={(e) => setManagedQuestion({...managedQuestion, title: e.target.value})}
-                        className={`input-field w-full bg-[#2D2942] ${!isEditing ? 'opacity-70 border-transparent cursor-default' : ''}`}
+                        className={`input-field w-full bg-[#2D2942]`}
                       />
                     </div>
                     <div className="space-y-2">
                       <label className="text-gray-400 text-xs font-bold uppercase tracking-wider ml-2">Topic</label>
-                      {isEditing ? (
-                        <select 
-                          value={managedQuestion.topic}
-                          onChange={(e) => setManagedQuestion({...managedQuestion, topic: e.target.value})}
-                          className="input-field w-full bg-[#2D2942] appearance-none"
-                        >
-                          <option>Arrays</option>
-                          <option>Strings</option>
-                          <option>Hash Tables</option>
-                          <option>Linked Lists</option>
-                          <option>Trees</option>
-                          <option>Graphs</option>
-                          <option>Greedy</option>
-                          <option>Dynamic Programming</option>
-                        </select>
-                      ) : (
+                      
                         <div className="input-field w-full bg-[#2D2942] opacity-70 border-transparent">{managedQuestion.topic}</div>
-                      )}
+                      
                     </div>
                   </div>
 
@@ -479,7 +391,7 @@ export function AdminPage({ currentUser, onLogout }: AdminPageProps) {
                     <label className="text-gray-400 text-xs font-bold uppercase tracking-wider ml-2">
                       Difficulty
                     </label>
-                    <div className={`flex gap-3 ${!isEditing ? 'pointer-events-none' : ''}`}>
+                    <div className={`flex gap-3`}>
                       {['Easy', 'Medium', 'Hard'].map((diff) => (
                         <button
                           key={diff}
@@ -500,14 +412,7 @@ export function AdminPage({ currentUser, onLogout }: AdminPageProps) {
                   {/* Problem Statement */}
                   <div className="space-y-2">
                     <label className="text-gray-400 text-xs font-bold uppercase tracking-wider ml-2">Problem Statement</label>
-                    {isEditing ? (
-                      <textarea 
-                        rows={6}
-                        value={managedQuestion.statement}
-                        onChange={(e) => setManagedQuestion({...managedQuestion, statement: e.target.value})}
-                        className="input-field w-full bg-[#2D2942] rounded-[20px] resize-none focus:ring-2 ring-[#E8B995]/50"
-                      />
-                    ) : (
+                    
                       <div className="prose prose-invert max-w-none text-white bg-[#2D2942]/50 p-6 rounded-[24px] border border-white/5">
                         <ReactMarkdown 
                           remarkPlugins={[remarkMath]} 
@@ -522,7 +427,7 @@ export function AdminPage({ currentUser, onLogout }: AdminPageProps) {
                           {managedQuestion.statement}
                         </ReactMarkdown>
                       </div>
-                    )}
+                    
                   </div>
 
                   <div className="space-y-10">
@@ -530,7 +435,7 @@ export function AdminPage({ currentUser, onLogout }: AdminPageProps) {
                     <DynamicArrayInput 
                       label="Examples" 
                       items={managedQuestion.examples || ['']} 
-                      isEditing={isEditing}
+                      isEditing={false}
                       minRows={4}
                       onUpdate={(val: string[]) => setManagedQuestion({...managedQuestion, examples: val})} 
                     />
@@ -538,7 +443,7 @@ export function AdminPage({ currentUser, onLogout }: AdminPageProps) {
                     <DynamicArrayInput 
                       label="Constraints" 
                       items={managedQuestion.constraints || ['']} 
-                      isEditing={isEditing}
+                      isEditing={false}
                       minRows={2}
                       onUpdate={(val: string[]) => setManagedQuestion({...managedQuestion, constraints: val})} 
                     />
@@ -546,7 +451,7 @@ export function AdminPage({ currentUser, onLogout }: AdminPageProps) {
                     <DynamicArrayInput 
                       label="Hints" 
                       items={managedQuestion.hints || ['']} 
-                      isEditing={isEditing}
+                      isEditing={false}
                       minRows={2}
                       onUpdate={(val: string[]) => setManagedQuestion({...managedQuestion, hints: val})} 
                     />
@@ -555,19 +460,19 @@ export function AdminPage({ currentUser, onLogout }: AdminPageProps) {
                   {/* Code Template */}
                   <div className="space-y-2">
                     <label className="text-gray-400 text-xs font-bold uppercase tracking-wider ml-2">Python Code Template</label>
-                    <div className={`rounded-[24px] overflow-hidden border-2 transition-all ${isEditing ? 'border-[#E8B995]' : 'border-white/5'}`}>
+                    <div className={`rounded-[24px] overflow-hidden border-2 transition-all border-white/5`}>
                       <CodeMirror
                         value={managedQuestion.template}
                         minHeight="150px"
                         theme={dracula}
                         extensions={[python()]}
-                        readOnly={!isEditing}
+                        readOnly={true}
                         onChange={(value) => setManagedQuestion({ ...managedQuestion, template: value })}
                       />
                     </div>
                   </div>
 
-                  {isEditing && (
+                  {/* {isEditing && (
                     <button 
                       onClick={handleUpdateQuestion}
                       disabled={actionLoading === 'update-q'}
@@ -576,7 +481,7 @@ export function AdminPage({ currentUser, onLogout }: AdminPageProps) {
                       {actionLoading === 'update-q' ? <Loader2 className="w-5 h-5 animate-spin" /> : <Save className="w-5 h-5" />}
                       Save Changes
                     </button>
-                  )}
+                  )} */}
                 </div>
               )}
             </>
@@ -585,7 +490,7 @@ export function AdminPage({ currentUser, onLogout }: AdminPageProps) {
       </div>
 
       {/* Add Question Modal (Remains similar but with direct creation) */}
-      {isAddingQuestion && (
+      {/* {isAddingQuestion && (
         <div className="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center p-6 z-50">
           <div className="bg-[#4A4563] rounded-[32px] w-full max-w-2xl max-h-[90vh] overflow-y-auto p-8 relative custom-scrollbar">
             <button 
@@ -714,7 +619,15 @@ export function AdminPage({ currentUser, onLogout }: AdminPageProps) {
             </form>
           </div>
         </div>
-      )}
+      )} */}
+
+      <QuestionModal 
+        isOpen={modalConfig.isOpen}
+        mode={modalConfig.mode}
+        initialData={modalConfig.data}
+        onClose={() => setModalConfig({ ...modalConfig, isOpen: false })}
+        onSuccess={handleModalSuccess}
+      />
 
       <style>{`
         .custom-scrollbar::-webkit-scrollbar {

--- a/frontend/src/components/ui/DynamicArrayInput.tsx
+++ b/frontend/src/components/ui/DynamicArrayInput.tsx
@@ -7,22 +7,25 @@ import rehypeKatex from 'rehype-katex';
 interface DynamicArrayInputProps {
   label: string;
   items: string[];
-  onUpdate: (newItems: string[]) => void;
+  onUpdate?: (newItems: string[]) => void;
   minRows?: number;
   isEditing?: boolean;
+  emptyMessage?: string;
 }
 
-export function DynamicArrayInput({label, items, onUpdate, minRows = 2, isEditing = true }: DynamicArrayInputProps) {
-  const handleAdd = () => onUpdate([...items, '']);
-  const handleRemove = (index: number) => onUpdate(items.filter((_, i) => i !== index));
+export function DynamicArrayInput({label, items, onUpdate, minRows = 2, isEditing = true, emptyMessage = "No content available." }: DynamicArrayInputProps) {
+  const hasActualContent = items.some(item => item && item.trim().length > 0);
+  const handleAdd = () => onUpdate?.([...items, '']);
+  const handleRemove = (index: number) => onUpdate?.(items.filter((_, i) => i !== index));
   const handleChange = (index: number, value: string) => {
     const newItems = [...items];
     newItems[index] = value;
-    onUpdate(newItems);
+    onUpdate?.(newItems);
   };
 
   return (
     <div className="space-y-3">
+      {/* Header stays the same */}
       <div className="flex justify-between items-center ml-2">
         <label className="text-gray-400 text-xs font-bold uppercase tracking-wider">{label}</label>
         {isEditing && (
@@ -35,54 +38,65 @@ export function DynamicArrayInput({label, items, onUpdate, minRows = 2, isEditin
           </button>
         )}
       </div>
+
       <div className="space-y-4">
-        {items.map((item, idx) => (
-          <div key={idx} className="flex gap-3 items-start animate-in fade-in slide-in-from-left-2">
-            <div className="relative flex-1">
-              <span className="absolute left-4 top-3 text-[#E8B995] font-mono text-xs z-10">
-                {idx + 1}.
-              </span>
-              
-              {isEditing ? (
-                <textarea 
-                  rows={minRows}
-                  className="input-field w-full pl-10 pt-2 text-sm bg-[#3A3552] resize-none whitespace-pre-wrap break-words" 
-                  value={item} 
-                  onChange={(e) => handleChange(idx, e.target.value)}
-                  onKeyDown={(e) => e.key === 'Enter' && e.stopPropagation()}
-                />
-              ) : (
-                <div className="w-full pl-10 pr-6 py-3 bg-[#2D2942]/40 rounded-2xl border border-white/5 overflow-hidden">
-                  <div className="prose prose-invert max-w-none text-sm text-white">
-                    <ReactMarkdown 
-                      remarkPlugins={[remarkMath]} 
-                      rehypePlugins={[rehypeKatex]}
-                      components={{
-                        ol: ({node, ...props}) => <ol className="list-decimal pl-4 mb-2" {...props} />,
-                        ul: ({node, ...props}) => <ul className="list-disc pl-4 mb-2" {...props} />,
-                        li: ({node, ...props}) => <li className="mb-1" {...props} />,
-                        p: ({node, ...props}) => <p className="leading-relaxed break-words whitespace-pre-wrap" {...props} />,
-                        code: ({node, ...props}) => <code className="bg-[#3A3552] px-1 rounded text-[#E8B995]" {...props} />
-                      }}
-                    >
-                      {item || "*No content provided.*"}
-                    </ReactMarkdown>
+        {/* VIEW MODE EMPTY STATE: If not editing and no content, show the message */}
+        {!isEditing && !hasActualContent ? (
+          <div className="ml-2 p-4 bg-[#2D2942]/20 border border-dashed border-white/10 rounded-2xl">
+            <p className="text-gray-500 italic text-sm text-center">
+              {emptyMessage}
+            </p>
+          </div>
+        ) : (
+          /* Map through items if editing OR if content exists */
+          items.map((item, idx) => (
+            <div key={idx} className="flex gap-3 items-start animate-in fade-in slide-in-from-left-2">
+              <div className="relative flex-1">
+                <span className="absolute left-4 top-3 text-[#E8B995] font-mono text-xs z-10">
+                  {idx + 1}.
+                </span>
+                
+                {isEditing ? (
+                  <textarea 
+                    rows={minRows}
+                    className="input-field w-full pl-10 pt-2 text-sm bg-[#3A3552] resize-none whitespace-pre-wrap break-words" 
+                    value={item} 
+                    onChange={(e) => handleChange(idx, e.target.value)}
+                    onKeyDown={(e) => e.key === 'Enter' && e.stopPropagation()}
+                  />
+                ) : (
+                  <div className="w-full pl-10 pr-6 py-3 bg-[#2D2942]/40 rounded-2xl border border-white/5 overflow-hidden">
+                    <div className="prose prose-invert max-w-none text-sm text-white">
+                      <ReactMarkdown 
+                        remarkPlugins={[remarkMath]} 
+                        rehypePlugins={[rehypeKatex]}
+                        components={{
+                          ol: ({node, ...props}) => <ol className="list-decimal pl-4 mb-2" {...props} />,
+                          ul: ({node, ...props}) => <ul className="list-disc pl-4 mb-2" {...props} />,
+                          li: ({node, ...props}) => <li className="mb-1" {...props} />,
+                          p: ({node, ...props}) => <p className="leading-relaxed break-words whitespace-pre-wrap" {...props} />,
+                          code: ({node, ...props}) => <code className="bg-[#3A3552] px-1 rounded text-[#E8B995]" {...props} />
+                        }}
+                      >
+                        {item || "*No content provided.*"}
+                      </ReactMarkdown>
+                    </div>
                   </div>
-                </div>
+                )}
+              </div>
+              
+              {isEditing && idx > 0 && (
+                <button 
+                  type="button"
+                  onClick={() => handleRemove(idx)} 
+                  className="mt-1.5 text-red-400 p-2 hover:bg-red-400/10 rounded-xl transition-colors"
+                >
+                  <X className="w-5 h-5" />
+                </button>
               )}
             </div>
-            
-            {isEditing && idx > 0 && (
-              <button 
-                type="button"
-                onClick={() => handleRemove(idx)} 
-                className="mt-1.5 text-red-400 p-2 hover:bg-red-400/10 rounded-xl transition-colors"
-              >
-                <X className="w-5 h-5" />
-              </button>
-            )}
-          </div>
-        ))}
+          ))
+        )}
       </div>
     </div>
   );

--- a/frontend/src/components/ui/QuestionModal.tsx
+++ b/frontend/src/components/ui/QuestionModal.tsx
@@ -1,0 +1,296 @@
+import { useState, useEffect } from 'react';
+import { X, Loader2, Save, PlusCircle, List  } from 'lucide-react';
+import { GATEWAY_URL } from '../../constants';
+import { DynamicArrayInput } from './DynamicArrayInput';
+import CodeMirror from '@uiw/react-codemirror';
+import { python } from '@codemirror/lang-python';
+import { dracula } from '@uiw/codemirror-theme-dracula';
+
+interface QuestionModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSuccess: (updatedData?: any) => void;
+  mode: 'add' | 'edit';
+  initialData?: any;
+}
+
+export function QuestionModal({ isOpen, onClose, onSuccess, mode, initialData }: QuestionModalProps) {
+  const [formData, setFormData] = useState({
+    title: '',
+    topic: 'Arrays',
+    difficulty: 'Easy',
+    statement: '',
+    template: '',
+    examples: [''],
+    constraints: [''],
+    hints: ['']
+  });
+  
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [existingTopics, setExistingTopics] = useState<string[]>([]);
+  const [isCreatingNewTopic, setIsCreatingNewTopic] = useState(false);
+  const [newTopicInput, setNewTopicInput] = useState('');
+  const [isLoadingTopics, setIsLoadingTopics] = useState(false);
+
+  // Sync state when opening
+useEffect(() => {
+    const fetchTopics = async () => {
+      setIsLoadingTopics(true);
+      try {
+        const token = localStorage.getItem('peerprep_token'); 
+        const response = await fetch(`${GATEWAY_URL}/question/topics`, {
+          headers: { 
+            'Authorization': `Bearer ${token}` 
+          }
+        });
+        if (response.ok) {
+          const data = await response.json();
+          let updatedTopics = [...data];
+
+          
+          if (mode === 'edit' && initialData?.topic && !updatedTopics.includes(initialData.topic)) {
+            updatedTopics.push(initialData.topic);
+          }
+
+          const sortedTopics = updatedTopics.sort((a, b) => a.localeCompare(b));
+          setExistingTopics(sortedTopics);
+
+          if (mode === 'add' && sortedTopics.length > 0) {
+            setFormData(prev => ({ ...prev, topic: sortedTopics[0] }));
+          }
+        }
+      } catch (err) {
+        console.error("Failed to fetch topics:", err);
+        setExistingTopics([]); 
+      } finally {
+        setIsLoadingTopics(false);
+      }
+    };
+
+    if (isOpen) fetchTopics();
+  }, [isOpen, mode, initialData?.topic]);
+
+  // Sync state when opening (Modified to handle topic logic)
+  useEffect(() => {
+    if (isOpen) {
+      setIsCreatingNewTopic(false); // Reset toggle
+      setNewTopicInput('');
+      if (mode === 'edit' && initialData) {
+        setFormData({ ...initialData });
+      } else {
+        setFormData({
+          title: '', topic: existingTopics[0] || 'Arrays', difficulty: 'Easy',
+          statement: '', template: '', examples: [''],
+          constraints: [''], hints: ['']
+        });
+      }
+    }
+  }, [isOpen, mode, initialData, existingTopics]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const finalData = {
+      ...formData,
+      topic: isCreatingNewTopic ? newTopicInput.trim() : formData.topic
+    };
+
+    if (isCreatingNewTopic && !newTopicInput.trim()) {
+      alert("Please enter a name for the new topic.");
+      return;
+    }
+    setIsSubmitting(true);
+    try {
+      const token = localStorage.getItem('peerprep_token');
+      const url = mode === 'add' 
+        ? `${GATEWAY_URL}/question/` 
+        : `${GATEWAY_URL}/question/${initialData.question_id}`;
+      
+      const response = await fetch(url, {
+        method: mode === 'add' ? 'POST' : 'PUT',
+        headers: { 
+          'Authorization': `Bearer ${token}`,
+          'Content-Type': 'application/json',
+          'X-User-Role': 'admin' 
+        },
+        body: JSON.stringify(finalData)
+      });
+
+      if (!response.ok) throw new Error(`Failed to ${mode} question`);
+      
+      const savedData = await response.json();
+      onSuccess(savedData);
+      onClose();
+    } catch (err: any) {
+      alert(err.message);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 bg-black/70 backdrop-blur-md flex items-center justify-center p-6 z-[100]">
+      <div className="bg-[#4A4563] rounded-[32px] w-full max-w-3xl max-h-[90vh] overflow-y-auto p-10 relative custom-scrollbar border border-white/10 shadow-2xl">
+        <button onClick={onClose} className="absolute top-6 right-6 text-gray-400 hover:text-white transition-colors">
+          <X className="w-8 h-8" />
+        </button>
+        
+        <h2 className="text-white font-bold text-3xl mb-8 flex items-center gap-3">
+          <div className={`w-3 h-8 rounded-full ${mode === 'add' ? 'bg-green-400' : 'bg-[#E8B995]'}`} />
+          {mode === 'add' ? 'Create New Question' : `Edit Question #${initialData.question_id}`}
+        </h2>
+        
+        <form onSubmit={handleSubmit} className="space-y-8">
+          {/* Basic Info Group */}
+          <div className="grid md:grid-cols-2 gap-6">
+            <div className="space-y-2">
+              <label className="text-[#E8B995] text-xs font-bold uppercase tracking-widest ml-1">Title</label>
+              <input 
+                required
+                value={formData.title}
+                onChange={(e) => setFormData({...formData, title: e.target.value})}
+                placeholder="e.g. Longest Palindromic Substring"
+                className="input-field w-full bg-[#3A3552]"
+              />
+            </div>
+            <div className="space-y-2">
+            <div className="flex justify-between items-center">
+                <label className="text-[#E8B995] text-xs font-bold uppercase tracking-widest ml-1">Topic</label>
+                <button 
+                type="button"
+                onClick={() => setIsCreatingNewTopic(!isCreatingNewTopic)}
+                className="text-[#E8B995] text-[10px] font-bold uppercase flex items-center gap-1 hover:underline"
+                >
+                {isCreatingNewTopic ? (
+                    <><List className="w-3 h-3" /> Select Existing</>
+                ) : (
+                    <><PlusCircle className="w-3 h-3" /> Create New Topic</>
+                )}
+                </button>
+            </div>
+
+            {isCreatingNewTopic ? (
+                <input 
+                required
+                autoFocus
+                value={newTopicInput}
+                onChange={(e) => setNewTopicInput(e.target.value)}
+                placeholder="Enter new topic name..."
+                className="input-field w-full bg-[#3A3552] border-[#E8B995]/50 focus:border-[#E8B995]"
+                />
+            ) : (
+                <div className="relative">
+                <select 
+                    value={formData.topic}
+                    onChange={(e) => setFormData({...formData, topic: e.target.value})}
+                    disabled={isLoadingTopics}
+                    className="input-field w-full bg-[#3A3552] appearance-none"
+                >
+                    {isLoadingTopics ? (
+                    <option>Loading topics...</option>
+                    ) : (
+                    existingTopics.map(t => (
+                        <option key={t} value={t}>{t}</option>
+                    ))
+                    )}
+                </select>
+                <div className="pointer-events-none absolute inset-y-0 right-0 flex items-center px-4 text-gray-400">
+                    <svg className="fill-current h-4 w-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M9.293 12.95l.707.707L15.657 8l-1.414-1.414L10 10.828 5.757 6.586 4.343 8z"/></svg>
+                </div>
+                </div>
+            )}
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <label className="text-[#E8B995] text-xs font-bold uppercase tracking-widest ml-1">Difficulty</label>
+            <div className="flex gap-4">
+              {['Easy', 'Medium', 'Hard'].map((diff) => (
+                <button
+                  key={diff}
+                  type="button"
+                  onClick={() => setFormData({...formData, difficulty: diff})}
+                  className={`flex-1 py-3 rounded-2xl font-bold transition-all border-2 ${
+                    formData.difficulty === diff 
+                    ? 'bg-[#E8B995] text-[#4A4563] border-[#E8B995]' 
+                    : 'bg-transparent text-white border-white/10 hover:border-white/30'
+                  }`}
+                >
+                  {diff}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <label className="text-[#E8B995] text-xs font-bold uppercase tracking-widest ml-1">Problem Statement (Markdown)</label>
+            <textarea 
+              required
+              rows={6}
+              value={formData.statement}
+              onChange={(e) => setFormData({...formData, statement: e.target.value})}
+              placeholder="Use Markdown to describe the problem..."
+              className="input-field w-full bg-[#3A3552] rounded-[24px] resize-none"
+            />
+          </div>
+
+          <div className="space-y-2">
+            <label className="text-[#E8B995] text-xs font-bold uppercase tracking-widest ml-1">Python Template</label>
+            <div className="rounded-[24px] overflow-hidden border-2 border-white/5">
+              <CodeMirror
+                value={formData.template}
+                minHeight="200px"
+                theme={dracula}
+                extensions={[python()]}
+                onChange={(value) => setFormData({ ...formData, template: value })}
+              />
+            </div>
+          </div>
+
+          <div className="space-y-10 border-y border-white/5 py-8">
+            <DynamicArrayInput 
+              label="Examples" 
+              items={formData.examples} 
+              isEditing={true}
+              onUpdate={(val) => setFormData({...formData, examples: val})} 
+            />
+            <DynamicArrayInput 
+              label="Constraints" 
+              items={formData.constraints} 
+              isEditing={true}
+              onUpdate={(val) => setFormData({...formData, constraints: val})} 
+            />
+            <DynamicArrayInput 
+              label="Hints" 
+              items={formData.hints} 
+              isEditing={true}
+              onUpdate={(val) => setFormData({...formData, hints: val})} 
+            />
+          </div>
+
+          {/* Action Buttons: Save or Discard */}
+          <div className="flex gap-4 sticky bottom-0 bg-[#4A4563] pt-4 pb-2">
+            <button 
+              type="button"
+              onClick={() => {
+                if (window.confirm("Discard all changes?")) onClose();
+              }}
+              className="flex-1 px-6 py-4 rounded-2xl font-bold text-gray-300 bg-white/5 hover:bg-white/10 transition-all"
+            >
+              Discard Changes
+            </button>
+            <button 
+              type="submit" 
+              disabled={isSubmitting}
+              className="flex-[2] btn-secondary py-4 text-lg flex items-center justify-center gap-2"
+            >
+              {isSubmitting ? <Loader2 className="w-6 h-6 animate-spin" /> : <Save className="w-6 h-6" />}
+              {mode === 'add' ? 'Create Question' : 'Save Changes'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/ui/QuestionModal.tsx
+++ b/frontend/src/components/ui/QuestionModal.tsx
@@ -12,9 +12,11 @@ interface QuestionModalProps {
   onSuccess: (updatedData?: any) => void;
   mode: 'add' | 'edit';
   initialData?: any;
+  topics: string[];
+  difficulties: string[];
 }
 
-export function QuestionModal({ isOpen, onClose, onSuccess, mode, initialData }: QuestionModalProps) {
+export function QuestionModal({ isOpen, onClose, onSuccess, mode, initialData, topics, difficulties }: QuestionModalProps) {
   const [formData, setFormData] = useState({
     title: '',
     topic: 'Arrays',
@@ -32,45 +34,6 @@ export function QuestionModal({ isOpen, onClose, onSuccess, mode, initialData }:
   const [newTopicInput, setNewTopicInput] = useState('');
   const [isLoadingTopics, setIsLoadingTopics] = useState(false);
   const [initialRef, setInitialRef] = useState(JSON.stringify(formData));
-
-  // Sync state when opening
-  useEffect(() => {
-    const fetchTopics = async () => {
-      setIsLoadingTopics(true);
-      try {
-        const token = localStorage.getItem('peerprep_token'); 
-        const response = await fetch(`${GATEWAY_URL}/question/topics`, {
-          headers: { 
-            'Authorization': `Bearer ${token}` 
-          }
-        });
-        if (response.ok) {
-          const data = await response.json();
-          let updatedTopics = [...data];
-
-          
-          if (mode === 'edit' && initialData?.topic && !updatedTopics.includes(initialData.topic)) {
-            updatedTopics.push(initialData.topic);
-          }
-
-          const sortedTopics = updatedTopics.sort((a, b) => a.localeCompare(b));
-          setExistingTopics(sortedTopics);
-
-          if (mode === 'add' && sortedTopics.length > 0) {
-            setFormData(prev => ({ ...prev, topic: sortedTopics[0] }));
-          }
-        }
-      } catch (err) {
-        console.error("Failed to fetch topics:", err);
-        setExistingTopics([]); 
-      } finally {
-        setIsLoadingTopics(false);
-      }
-    };
-
-    if (isOpen) fetchTopics();
-  }, [isOpen, mode, initialData?.topic]);
-
  
   useEffect(() => {
     if (isOpen) {
@@ -87,53 +50,81 @@ export function QuestionModal({ isOpen, onClose, onSuccess, mode, initialData }:
     const hasUnsavedChanges = JSON.stringify(formData) !== initialRef || (isCreatingNewTopic && newTopicInput !== '');
 
     const handleCloseAttempt = () => {
-    if (hasUnsavedChanges) {
-        if (window.confirm("You have unsaved changes. Are you sure you want to discard them?")) {
-        onClose();
+        if (hasUnsavedChanges) {
+            if (window.confirm("You have unsaved changes. Are you sure you want to discard them?")) {
+                onClose();
+            }
+        } else {
+            onClose();
         }
-    } else {
-        onClose();
-    }
     };
 
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    const finalData = {
-      ...formData,
-      topic: isCreatingNewTopic ? newTopicInput.trim() : formData.topic
+    const handleSubmit = async (e: React.FormEvent) => {
+        e.preventDefault();
+
+        const cleanTitle = String(formData.title).trim();
+        const cleanTopic = isCreatingNewTopic
+            ? String(newTopicInput).trim()
+            : String(formData.topic).trim();
+
+        const reservedNames = ['all', 'all topics', 'any', 'any topic', 'all topic'];
+        if (isCreatingNewTopic && reservedNames.includes(cleanTopic.toLowerCase())) {
+            alert(`"${cleanTopic}" is a reserved system name. Please choose a different name.`);
+            return;
+        }
+
+        if (!cleanTitle || !cleanTopic) {
+            alert("Title and Topic cannot be empty or just whitespace.");
+            return;
+        }
+
+        const finalData = {
+            ...formData,
+            title: cleanTitle,
+            topic: cleanTopic,
+            statement: formData.statement.trim()
+        };
+
+        setIsSubmitting(true);
+        try {
+            const token = localStorage.getItem('peerprep_token');
+            const url = mode === 'add'
+                ? `${GATEWAY_URL}/question/`
+                : `${GATEWAY_URL}/question/${initialData.question_id}`;
+
+            const response = await fetch(url, {
+                method: mode === 'add' ? 'POST' : 'PUT',
+                headers: {
+                    'Authorization': `Bearer ${token}`,
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify(finalData)
+            });
+
+            if (!response.ok) throw new Error(`Failed to ${mode} question`);
+
+            const savedData = await response.json();
+            onSuccess(savedData);
+            onClose();
+        } catch (err: any) {
+            alert(err.message);
+        } finally {
+            setIsSubmitting(false);
+        }
     };
 
-    if (isCreatingNewTopic && !newTopicInput.trim()) { // prevent the admin from creating a new topic with an empty name (using a space to bypass the default value check)
-      alert("Please enter a name for the new topic");
-      return;
-    }
-    setIsSubmitting(true);
-    try {
-      const token = localStorage.getItem('peerprep_token');
-      const url = mode === 'add' 
-        ? `${GATEWAY_URL}/question/` 
-        : `${GATEWAY_URL}/question/${initialData.question_id}`;
-      
-      const response = await fetch(url, {
-        method: mode === 'add' ? 'POST' : 'PUT',
-        headers: { 
-          'Authorization': `Bearer ${token}`,
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify(finalData)
-      });
+    useEffect(() => {
+      const handleBeforeUnload = (e: BeforeUnloadEvent) => {
+          // intercept if the modal is actually open and has changes
+          if (isOpen && hasUnsavedChanges) {
+              e.preventDefault();
+              e.returnValue = ''; // Trigger the browser's generic "Discard changes?" box
+          }
+      };
 
-      if (!response.ok) throw new Error(`Failed to ${mode} question`);
-      
-      const savedData = await response.json();
-      onSuccess(savedData);
-      onClose();
-    } catch (err: any) {
-      alert(err.message);
-    } finally {
-      setIsSubmitting(false);
-    }
-  };
+      window.addEventListener('beforeunload', handleBeforeUnload);
+      return () => window.removeEventListener('beforeunload', handleBeforeUnload);
+  }, [isOpen, hasUnsavedChanges]);
 
   if (!isOpen) return null;
 
@@ -191,16 +182,11 @@ export function QuestionModal({ isOpen, onClose, onSuccess, mode, initialData }:
                 <select 
                     value={formData.topic}
                     onChange={(e) => setFormData({...formData, topic: e.target.value})}
-                    disabled={isLoadingTopics}
                     className="input-field w-full bg-[#3A3552] appearance-none"
                 >
-                    {isLoadingTopics ? (
-                    <option>Loading topics...</option>
-                    ) : (
-                    existingTopics.map(t => (
+                    {topics.map(t => (
                         <option key={t} value={t}>{t}</option>
-                    ))
-                    )}
+                    ))}
                 </select>
                 <div className="pointer-events-none absolute inset-y-0 right-0 flex items-center px-4 text-gray-400">
                     <svg className="fill-current h-4 w-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M9.293 12.95l.707.707L15.657 8l-1.414-1.414L10 10.828 5.757 6.586 4.343 8z"/></svg>

--- a/frontend/src/components/ui/QuestionModal.tsx
+++ b/frontend/src/components/ui/QuestionModal.tsx
@@ -31,9 +31,10 @@ export function QuestionModal({ isOpen, onClose, onSuccess, mode, initialData }:
   const [isCreatingNewTopic, setIsCreatingNewTopic] = useState(false);
   const [newTopicInput, setNewTopicInput] = useState('');
   const [isLoadingTopics, setIsLoadingTopics] = useState(false);
+  const [initialRef, setInitialRef] = useState(JSON.stringify(formData));
 
   // Sync state when opening
-useEffect(() => {
+  useEffect(() => {
     const fetchTopics = async () => {
       setIsLoadingTopics(true);
       try {
@@ -70,22 +71,30 @@ useEffect(() => {
     if (isOpen) fetchTopics();
   }, [isOpen, mode, initialData?.topic]);
 
-  // Sync state when opening (Modified to handle topic logic)
+ 
   useEffect(() => {
     if (isOpen) {
-      setIsCreatingNewTopic(false); // Reset toggle
-      setNewTopicInput('');
-      if (mode === 'edit' && initialData) {
-        setFormData({ ...initialData });
-      } else {
-        setFormData({
-          title: '', topic: existingTopics[0] || 'Arrays', difficulty: 'Easy',
-          statement: '', template: '', examples: [''],
-          constraints: [''], hints: ['']
-        });
-      }
+        const dataToLoad = (mode === 'edit' && initialData) ? initialData : {
+        title: '', topic: existingTopics[0] || 'Arrays', difficulty: 'Easy',
+        statement: '', template: '', examples: [''],
+        constraints: [''], hints: ['']
+        };
+        setFormData(dataToLoad);
+        setInitialRef(JSON.stringify(dataToLoad));
     }
-  }, [isOpen, mode, initialData, existingTopics]);
+    }, [isOpen, mode, initialData, existingTopics]);
+
+    const hasUnsavedChanges = JSON.stringify(formData) !== initialRef || (isCreatingNewTopic && newTopicInput !== '');
+
+    const handleCloseAttempt = () => {
+    if (hasUnsavedChanges) {
+        if (window.confirm("You have unsaved changes. Are you sure you want to discard them?")) {
+        onClose();
+        }
+    } else {
+        onClose();
+    }
+    };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -94,8 +103,8 @@ useEffect(() => {
       topic: isCreatingNewTopic ? newTopicInput.trim() : formData.topic
     };
 
-    if (isCreatingNewTopic && !newTopicInput.trim()) {
-      alert("Please enter a name for the new topic.");
+    if (isCreatingNewTopic && !newTopicInput.trim()) { // prevent the admin from creating a new topic with an empty name (using a space to bypass the default value check)
+      alert("Please enter a name for the new topic");
       return;
     }
     setIsSubmitting(true);
@@ -110,7 +119,6 @@ useEffect(() => {
         headers: { 
           'Authorization': `Bearer ${token}`,
           'Content-Type': 'application/json',
-          'X-User-Role': 'admin' 
         },
         body: JSON.stringify(finalData)
       });
@@ -132,13 +140,12 @@ useEffect(() => {
   return (
     <div className="fixed inset-0 bg-black/70 backdrop-blur-md flex items-center justify-center p-6 z-[100]">
       <div className="bg-[#4A4563] rounded-[32px] w-full max-w-3xl max-h-[90vh] overflow-y-auto p-10 relative custom-scrollbar border border-white/10 shadow-2xl">
-        <button onClick={onClose} className="absolute top-6 right-6 text-gray-400 hover:text-white transition-colors">
+        <button onClick={handleCloseAttempt} className="absolute top-6 right-6 text-gray-400 hover:text-white transition-colors">
           <X className="w-8 h-8" />
         </button>
         
         <h2 className="text-white font-bold text-3xl mb-8 flex items-center gap-3">
-          <div className={`w-3 h-8 rounded-full ${mode === 'add' ? 'bg-green-400' : 'bg-[#E8B995]'}`} />
-          {mode === 'add' ? 'Create New Question' : `Edit Question #${initialData.question_id}`}
+          {mode === 'add' ? 'Add New Question' : `Edit Question #${initialData.question_id}`}
         </h2>
         
         <form onSubmit={handleSubmit} className="space-y-8">
@@ -270,20 +277,18 @@ useEffect(() => {
           </div>
 
           {/* Action Buttons: Save or Discard */}
-          <div className="flex gap-4 sticky bottom-0 bg-[#4A4563] pt-4 pb-2">
+          <div className="flex gap-4  bottom-0 bg-[#4A4563] pt-4 pb-2">
             <button 
               type="button"
-              onClick={() => {
-                if (window.confirm("Discard all changes?")) onClose();
-              }}
+              onClick={handleCloseAttempt}
               className="flex-1 px-6 py-4 rounded-2xl font-bold text-gray-300 bg-white/5 hover:bg-white/10 transition-all"
             >
-              Discard Changes
+              Discard
             </button>
             <button 
               type="submit" 
               disabled={isSubmitting}
-              className="flex-[2] btn-secondary py-4 text-lg flex items-center justify-center gap-2"
+              className="flex-1 btn-secondary py-4 text-lg flex items-center justify-center gap-2"
             >
               {isSubmitting ? <Loader2 className="w-6 h-6 animate-spin" /> : <Save className="w-6 h-6" />}
               {mode === 'add' ? 'Create Question' : 'Save Changes'}


### PR DESCRIPTION
## Backend
Add 3 new endpoints
- GET /question/all: Fetches a paginated list of questions with optional server-side filtering by topic and difficulty.
- GET /question/metadata: Returns the current list of unique topics and difficulty levels available in the database for UI dropdowns.
- GET /question/{id}: Retrieves the comprehensive details (statement, examples, hints, and template) for a specific question by its ID.

## Frontend
- Added server-side pagination (10 questions per page).
- Implemented expandable question rows to fetch full details on-demand.
- Added dual search functionality: exact Question ID lookup OR Topic/Difficulty filtering.
- Implemented "Reset All" logic to clear active search/filter states.
- Ensured automatic page refresh after add, update, or delete actions.
- Added input validation to prevent reserved topic names and handle numeric titles.