### PR TITLE
Add disconnect handlers to prevent toast when user leave session

### DIFF
--- a/frontend/src/components/CollaborationPage.tsx
+++ b/frontend/src/components/CollaborationPage.tsx
@@ -96,6 +96,7 @@ export function CollaborationPage() {
   const partnerRef = useRef<PartnerInfo | null>(null);
   const partnerTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const partnerEndedRef = useRef(false);
+  const sessionEndedRef = useRef(false);
   const startedAtRef = useRef<number>(Date.now());
 
   // Keep partner ref in sync for use in chat socket handlers
@@ -220,10 +221,10 @@ export function CollaborationPage() {
         });
 
         editorSocket.on('disconnect', async () => {
-          if (cleaned) return;
+          if (cleaned || sessionEndedRef.current) return;
           try {
             const newTicket = await fetchTicket(sessionId);
-            if (cleaned) return;
+            if (cleaned || sessionEndedRef.current) return;
             editorSocket.io.opts.query = { ticket: newTicket };
             editorSocket.connect();
             toast('Reconnecting editor...');
@@ -298,10 +299,10 @@ export function CollaborationPage() {
         });
 
         chatSocket.on('disconnect', async () => {
-          if (cleaned) return;
+          if (cleaned || sessionEndedRef.current) return;
           try {
             const newTicket = await fetchTicket(sessionId);
-            if (cleaned) return;
+            if (cleaned || sessionEndedRef.current) return;
             chatSocket.io.opts.query = { ticket: newTicket };
             chatSocket.connect();
           } catch {
@@ -346,6 +347,7 @@ export function CollaborationPage() {
 
   // --- 5a. End Session ---
   const handleEndSession = useCallback(async () => {
+    sessionEndedRef.current = true;
     editorSocketRef.current?.emit('end-session');
     editorSocketRef.current?.disconnect();
     chatSocketRef.current?.disconnect();


### PR DESCRIPTION
## Description:
When a user explicitly ended a session, the editor would show "Reconnecting editor..." and "Editor connected" toasts
before navigating to the dashboard. This happened because calling socket.disconnect() triggers the disconnect event handler, which would race to fetch a new ticket and reconnect before the component unmounted and set cleaned = true.

## Root cause: 
The disconnect handlers had no way to distinguish an intentional session end from a genuine network dropout.

## Fix: 
Added a sessionEndedRef (mirroring the existing partnerEndedRef pattern). It is set to true at the start of
handleEndSession, before any disconnect() calls. Both the editor and chat socket disconnect handlers now check this
ref and bail out immediately, suppressing the reconnect attempt and associated toast notifications.

## Changes:
- frontend/src/components/CollaborationPage.tsx
- Added sessionEndedRef ref
- Set sessionEndedRef.current = true at start of handleEndSession
- Added sessionEndedRef.current guard to editor socket disconnect handler
- Added sessionEndedRef.current guard to chat socket disconnect handler

## Testing:
- End session → should navigate to dashboard with no reconnect toasts
- Network dropout mid-session → should still show "Reconnecting editor..." as expected
- Partner ends session → partner-ended flow unaffected