### PR TITLE
Fix bug where Disconnect happens even though user disconnected

### DIFF
--- a/backend/collaboration-service/server.js
+++ b/backend/collaboration-service/server.js
@@ -29,7 +29,10 @@ redisClient.connect().then(() => console.log('Connected to redis-sessions'));
 const sessions = new Map();
 // sessions.get(sessionId) = {
 //   ydoc: Y.Doc,
-//   connectedEditors: Set<string>,   // userIds
+//   connectedEditors: Set<string>,   // userIds currently connected via socket
+//   endedUsers: Set<string>,          // userIds who explicitly ended session
+//   userDisconnectTimers: Map<string, Timeout>,
+//   activeSocketIds: Map<string, string>,
 //   disconnectTimer: Timeout | null
 // }
 
@@ -75,7 +78,9 @@ async function getOrCreateSession(sessionId) {
   const session = {
     ydoc,
     connectedEditors: new Set(),
+    endedUsers: new Set(),            // users who explicitly ended via end-session
     userDisconnectTimers: new Map(),  // userId -> timeout (30s per-user disconnect)
+    activeSocketIds: new Map(),       // userId -> latest socket.id
     disconnectTimer: null
   };
   sessions.set(sessionId, session);
@@ -89,21 +94,28 @@ editorNs.on('connection', async (socket) => {
   const { userId, sessionId } = socket;
   if (!userId || !sessionId) return socket.disconnect(true);
 
-  console.log(`[editor] ${userId} connected (${socket.id})`);
-
   const session = await getOrCreateSession(sessionId);
+
+  // Check before setting — if an entry exists, this user was here before
+  const isReconnect = session.activeSocketIds.has(userId);
+
+  // Register this as the latest socket for the user
+  session.activeSocketIds.set(userId, socket.id);
 
   // Clear any disconnect timers for this user (they reconnected in time)
   if (session.userDisconnectTimers.has(userId)) {
     clearTimeout(session.userDisconnectTimers.get(userId));
     session.userDisconnectTimers.delete(userId);
+    console.log(`[cancelTimer] Cleared user disconnect timer for ${userId} (reconnected, session=${sessionId})`);
   }
   if (session.disconnectTimer) {
     clearTimeout(session.disconnectTimer);
     session.disconnectTimer = null;
+    console.log(`[cancelTimer] Cleared session cleanup timer (reconnect by ${userId}, session=${sessionId})`);
   }
 
   session.connectedEditors.add(userId);
+  console.log(`[connect] ${userId} ${isReconnect ? 'reconnected' : 'connected'} (socket=${socket.id}, session=${sessionId}, editors=${[...session.connectedEditors]})`);
   socket.join(sessionId);
 
   // Send full document state to this client
@@ -141,8 +153,11 @@ editorNs.on('connection', async (socket) => {
     socket.to(sessionId).emit('yjs-update', data);
   });
 
-  socket.on('end-session', async () => {
-    console.log(`[editor] ${userId} ended session ${sessionId}`);
+  socket.on('end-session', async (ack) => {
+    console.log(`[end-session] ${userId} explicitly ended session (socket=${socket.id}, session=${sessionId}, editors=${[...session.connectedEditors]})`);
+
+    // Mark this user as explicitly ended so the disconnect timer won't double-save
+    session.endedUsers.add(userId);
 
     // Snapshot the code at the moment this user leaves
     const finalCode = session.ydoc.getText('code').toString();
@@ -156,44 +171,98 @@ editorNs.on('connection', async (socket) => {
 
     // Notify remaining users — they get a prompt to continue or leave
     socket.to(sessionId).emit('partner-ended', { userId });
+
+    // Acknowledge so the client knows it's safe to disconnect
+    if (typeof ack === 'function') ack();
   });
 
   socket.on('disconnect', () => {
-    console.log(`[editor] ${userId} disconnected (${socket.id})`);
     session.connectedEditors.delete(userId);
 
-    // Notify partner about temporary disconnect
+    // If the user already explicitly ended, skip the disconnect timer entirely —
+    // history is already saved and partner was already notified.
+    if (session.endedUsers.has(userId)) {
+      console.log(`[disconnect] ${userId} socket closed after explicit end-session, skipping timer (socket=${socket.id}, session=${sessionId})`);
+
+      // Still need to check if session needs cleanup (both users gone)
+      if (session.connectedEditors.size === 0) {
+        if (session.disconnectTimer) {
+          clearTimeout(session.disconnectTimer);
+        }
+        console.log(`[setTimer] Started 5s session cleanup timer (session=${sessionId})`);
+        session.disconnectTimer = setTimeout(async () => {
+          console.log(`[cleanup] Session cleanup timer fired, cleaning up (session=${sessionId})`);
+          try {
+            await handleSessionEnded(sessionId);
+          } catch (err) {
+            console.error(`[cleanup] Failed to clean up session ${sessionId}: ${err.message}`);
+          }
+          sessions.delete(sessionId);
+          console.log(`[cleanup] Session ${sessionId} removed from memory`);
+        }, 5000);
+      }
+      return;
+    }
+
+    console.log(`[disconnect] ${userId} socket closed (socket=${socket.id}, session=${sessionId}, editorsLeft=${[...session.connectedEditors]})`);
+
+    // Notify partner about unexpected disconnect
     editorNs.to(sessionId).emit('user-left', {
       userId,
       message: 'Your partner has disconnected.'
     });
 
+    // Capture which socket triggered this disconnect
+    const disconnectingSocketId = socket.id;
+
     // Start 30s timer for this user — if they don't reconnect, treat as end-session
+    console.log(`[setTimer] Started 30s disconnect timer for ${userId} (disconnectSocket=${disconnectingSocketId}, session=${sessionId})`);
+
     const userTimer = setTimeout(async () => {
       session.userDisconnectTimers.delete(userId);
-      console.log(`[disconnect-timeout] ${userId} did not reconnect, treating as end-session`);
+      const currentSocketId = session.activeSocketIds.get(userId);
 
-      // Snapshot and save this user's history
+      // If the user reconnected, their active socket ID will differ from the one that disconnected
+      if (currentSocketId !== disconnectingSocketId) {
+        console.log(`[timerFired] ${userId} reconnected via new socket (old=${disconnectingSocketId}, new=${currentSocketId}), skipping (session=${sessionId})`);
+        return;
+      }
+
+      // Check if the REST end-session endpoint already ran (frontend race: disconnect fires
+      // before the server processes the end-session socket event)
+      const activeSessionVal = await redisClient.get(`active_session:${userId}`);
+      const restEndedEarly = activeSessionVal === null || activeSessionVal !== sessionId;
+
       const finalCode = session.ydoc.getText('code').toString();
       try {
         await handleUserEnded(sessionId, userId, finalCode);
       } catch (err) {
-        console.error(`[disconnect-timeout] Failed to save history for ${userId}: ${err.message}`);
+        console.error(`[timerFired] Failed to save history for ${userId}: ${err.message}`);
       }
 
-      // Notify remaining users with the same prompt as end-session
-      editorNs.to(sessionId).emit('partner-ended', { userId });
+      if (restEndedEarly) {
+        console.log(`[timerFired] ${userId} ended via REST before socket event arrived, history saved (session=${sessionId})`);
+      } else {
+        console.log(`[timerFired] ${userId} did not reconnect after 30s, treating as end-session (session=${sessionId})`);
+        editorNs.to(sessionId).emit('partner-ended', { userId });
+      }
 
-      // If no one is left, start full session cleanup
+      // Check if session needs cleanup
       if (session.connectedEditors.size === 0) {
+        if (session.disconnectTimer) {
+          clearTimeout(session.disconnectTimer);
+          console.log(`[cancelTimer] Cleared previous session cleanup timer before setting new one (session=${sessionId})`);
+        }
+        console.log(`[setTimer] Started 5s session cleanup timer (session=${sessionId})`);
         session.disconnectTimer = setTimeout(async () => {
+          console.log(`[cleanup] Session cleanup timer fired, cleaning up (session=${sessionId})`);
           try {
             await handleSessionEnded(sessionId);
           } catch (err) {
-            console.error(`[cleanup] Failed to clean up session: ${err.message}`);
+            console.error(`[cleanup] Failed to clean up session ${sessionId}: ${err.message}`);
           }
           sessions.delete(sessionId);
-          console.log(`[cleanup] Session ${sessionId} cleaned up`);
+          console.log(`[cleanup] Session ${sessionId} removed from memory`);
         }, 5000);
       }
     }, 30000);
@@ -242,8 +311,18 @@ chatNs.on('connection', async (socket) => {
 // ==========================================
 
 async function handleUserEnded(sessionId, userId, finalCode) {
+  // Idempotent: skip if history was already saved for this user+session
+  const alreadySaved = await redisClient.get(`session:${sessionId}:saved:${userId}`);
+  if (alreadySaved) {
+    console.log(`[history] Skipping duplicate save for ${userId} (session=${sessionId}, already saved)`);
+    return;
+  }
+
   const raw = await redisClient.get(`session:${sessionId}:meta`);
-  if (!raw) return;
+  if (!raw) {
+    console.log(`[history] Skipping save for ${userId} (session=${sessionId}, meta not found — already cleaned up)`);
+    return;
+  }
   const meta = JSON.parse(raw);
   const payload = {
     ...meta,
@@ -252,20 +331,37 @@ async function handleUserEnded(sessionId, userId, finalCode) {
     endedAt: Date.now() / 1000,
     submittedBy: userId
   };
+  console.log(`[history] Saving history for ${userId} (session=${sessionId}, question=${meta.questionId})`);
   await axios.post('http://history-service:6770/history', payload);
-  await redisClient.del(`active_session:${userId}`);
+  console.log(`[history] History saved successfully for ${userId} (session=${sessionId})`);
+
+  // Only clear the active session pointer if it still refers to this session —
+  // the user may have already joined a new session by the time this runs.
+  const currentActiveSession = await redisClient.get(`active_session:${userId}`);
+  if (currentActiveSession === sessionId) {
+    await redisClient.del(`active_session:${userId}`);
+    console.log(`[history] Cleared active_session for ${userId} (session=${sessionId})`);
+  } else {
+    console.log(`[history] active_session for ${userId} already cleared (session=${sessionId})`);
+  }
   await redisClient.set(`session:${sessionId}:saved:${userId}`, '1', { EX: 7200 });
 }
 
 async function handleSessionEnded(sessionId) {
+  console.log(`[session-cleanup] Starting full cleanup (session=${sessionId})`);
   const raw = await redisClient.get(`session:${sessionId}:meta`);
-  if (!raw) return; // already cleaned up
+  if (!raw) {
+    console.log(`[session-cleanup] Meta not found, already cleaned up (session=${sessionId})`);
+    return;
+  }
   const meta = JSON.parse(raw);
   const finalCode = (await redisClient.get(`session:${sessionId}:finalCode`)) || '';
+
   for (const key of ['user1_id', 'user2_id']) {
     const uid = meta[key];
     const saved = await redisClient.get(`session:${sessionId}:saved:${uid}`);
     if (!saved) {
+      console.log(`[session-cleanup] Catch-up save for ${uid} who never explicitly ended (session=${sessionId})`);
       const payload = {
         ...meta,
         sessionId,
@@ -274,18 +370,34 @@ async function handleSessionEnded(sessionId) {
         submittedBy: uid
       };
       await axios.post('http://history-service:6770/history', payload);
+      console.log(`[session-cleanup] Catch-up history saved for ${uid} (session=${sessionId})`);
+    } else {
+      console.log(`[session-cleanup] ${uid} already saved, skipping (session=${sessionId})`);
     }
   }
+
+  // Clean up session-scoped keys
   await redisClient.del(
     `session:${sessionId}:meta`,
     `session:${sessionId}:finalCode`,
     `session:${sessionId}:ydoc`,
     `session:${sessionId}:chat`,
     `session:${sessionId}:saved:${meta.user1_id}`,
-    `session:${sessionId}:saved:${meta.user2_id}`,
-    `active_session:${meta.user1_id}`,
-    `active_session:${meta.user2_id}`
+    `session:${sessionId}:saved:${meta.user2_id}`
   );
+  console.log(`[session-cleanup] Redis session keys deleted (session=${sessionId})`);
+
+  // Only clear active_session pointers if they still refer to this session —
+  // either user may have already joined a new session by now.
+  for (const uid of [meta.user1_id, meta.user2_id]) {
+    const current = await redisClient.get(`active_session:${uid}`);
+    if (current === sessionId) {
+      await redisClient.del(`active_session:${uid}`);
+      console.log(`[session-cleanup] Cleared active_session for ${uid} (session=${sessionId})`);
+    } else {
+      console.log(`[session-cleanup] active_session for ${uid} already cleared (session=${sessionId})`);
+    }
+  }
 }
 
 // ==========================================
@@ -354,7 +466,10 @@ app.post('/collab/end-session/:sessionId', async (req, res) => {
   if (![meta.user1_id, meta.user2_id].includes(uid)) {
     return res.status(403).json({ detail: 'Not a member of this session' });
   }
-  await redisClient.del(`active_session:${uid}`);
+  const currentActive = await redisClient.get(`active_session:${uid}`);
+  if (currentActive === sessionId) {
+    await redisClient.del(`active_session:${uid}`);
+  }
   res.json({ detail: 'Active session cleared' });
 });
 

--- a/docs/SessionEndScenarios.md
+++ b/docs/SessionEndScenarios.md
@@ -1,0 +1,207 @@
+---
+editor-width:
+cssclasses:
+  - wide-note
+---
+# Session End Scenarios
+
+All possible ways a collaborative session can terminate, from both users' perspectives.
+
+---
+
+## Quick Reference
+
+| # | Trigger | By | Partner sees | History saved |
+|---|---------|-----|--------------|---------------|
+| 1 | Click "End Session" | You | Modal: Stay / End | Immediately |
+| 2 | Click "End Session" | Partner | Modal: Stay / End | Immediately |
+| 3 | Close tab / navigate away, return < 30s | You | "Reconnecting..." → "Active now" | No (resumed) |
+| 4 | Close tab / navigate away, return < 30s | Partner | "Reconnecting..." → "Active now" | No (resumed) |
+| 5 | Close tab / navigate away, never return | You | "Reconnecting..." → modal after 30s | After 30s timeout |
+| 6 | Close tab / navigate away, never return | Partner | "Reconnecting..." → modal after 30s | After 30s timeout |
+| 7 | Network drop, recovers < 30s | Either | "Reconnecting..." → "Active now" | No (resumed) |
+| 8 | Network drop, does not recover | Either | Same as close tab (scenarios 5/6) | After 30s timeout |
+| 9 | Both disconnect simultaneously | Both | — | Each after 30s, Redis wiped after +5s |
+| 10 | Stay alone after partner left, then close tab | You | — | After 30s timeout |
+| 11 | Stay alone after partner left, click "End Session" | You | — | Immediately |
+
+---
+
+## Detailed Flow
+
+```
+╔══════════════════════════════════════════════════════════════════╗
+║                    SESSION END — ALL SCENARIOS                   ║
+╚══════════════════════════════════════════════════════════════════╝
+
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ SCENARIO 1 & 2 — Someone clicks "End Session"
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  [User A clicks End Session]
+        │
+        ├─ emit 'end-session' to server
+        ├─ disconnect both sockets
+        ├─ POST /collab/end-session  ──► clears active_session in Redis
+        └─ navigate to /dashboard
+        │
+        ▼
+  [Server receives 'end-session']
+        ├─ snapshot finalCode from Yjs
+        ├─ POST history-service      ──► User A's history saved
+        ├─ del active_session:userA
+        └─ emit 'partner-ended' ─────────────────────────────────┐
+                                                                  ▼
+                                                   [User B sees modal]
+                                                    "Partner has left"
+                                                    ├─ [Continue Coding]
+                                                    │   modal closes, B stays alone
+                                                    │   ──► Scenario 10 or 11
+                                                    └─ [End Session]
+                                                        ──► same flow as above
+                                                            for User B
+
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ SCENARIO 3 & 4 — Close tab / navigate away, return < 30s
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  [User A closes tab or navigates away]
+        │
+        ▼
+  React cleanup: editorSocket.disconnect()
+        │
+        ▼
+  [Server: 'disconnect' event]
+        ├─ remove A from connectedEditors
+        ├─ emit 'user-left' ──────────────► [User B: status → "Reconnecting..."]
+        └─ start 30s per-user timer
+        │
+        │  (User A reopens within 30s)
+        ▼
+  fetchTicket() → new WebSocket connection
+        │
+        ▼
+  [Server: 'connection' event]
+        ├─ cancel 30s timer
+        ├─ re-add A to connectedEditors
+        ├─ emit 'yjs-sync' ──────────────► User A gets full doc state back
+        └─ emit 'user-joined' ───────────► [User B: status → "Active now"]
+        │
+        ▼
+  Session continues normally, nothing saved
+
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ SCENARIO 5 & 6 — Close tab / navigate away, never return
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  [User A closes tab or navigates away]
+        │
+        ▼
+  React cleanup: editorSocket.disconnect()
+        │
+        ▼
+  [Server: 'disconnect' event]
+        ├─ emit 'user-left' ──────────────► [User B: status → "Reconnecting..."]
+        └─ start 30s per-user timer
+        │
+        ▼ (30 seconds — no reconnect)
+  [Timer fires]
+        ├─ snapshot finalCode
+        ├─ POST history-service      ──► User A's history saved
+        ├─ del active_session:userA
+        └─ emit 'partner-ended' ─────────────────────────────────┐
+                                                                  ▼
+                                                   [User B sees modal]
+                                                    "Partner has left"
+                                                    ├─ [Continue Coding]
+                                                    │   B stays alone
+                                                    │   ──► Scenario 10 or 11
+                                                    └─ [End Session]
+                                                        ──► Scenario 1/2 flow
+
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ SCENARIO 7 & 8 — Network drop
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  [Network drops for User A]
+        │
+        ▼
+  WebSocket connection lost (same server-side effect as close tab)
+        │
+        ├─ Recovers < 30s ──► same as Scenario 3 & 4
+        │
+        └─ Does not recover ──► same as Scenario 5 & 6
+
+  Note: Frontend auto-reconnect (fetchTicket → socket.connect())
+        is attempted on every 'disconnect' event unless
+        sessionEndedRef is true.
+
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ SCENARIO 9 — Both disconnect simultaneously
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  [Both users disconnect around the same time]
+        │
+        ▼
+  Both 30s per-user timers start independently
+        │
+        ▼ (both timers fire — up to 30s apart)
+  For each user:
+        ├─ history saved individually (idempotent, skip if already saved)
+        └─ del active_session:userId
+        │
+        ▼ (connectedEditors.size === 0)
+  [5s full session cleanup timer starts]
+        │
+        ▼
+  handleSessionEnded()
+        ├─ save history for any user not yet saved
+        └─ delete all Redis keys:
+            session:meta, finalCode, ydoc, chat,
+            saved:user1, saved:user2,
+            active_session:user1, active_session:user2
+
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ SCENARIO 10 & 11 — User stays alone after partner left
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  User B chose [Continue Coding] after seeing partner-ended modal.
+  partnerEndedRef = true on B's client.
+
+  SCENARIO 10 — B then closes tab:
+        │
+        ▼
+  editorSocket.disconnect()
+        │
+        ▼
+  [Server: 'disconnect' event]
+        ├─ no partner to notify (connectedEditors now empty)
+        ├─ start 30s per-user timer for B
+        └─ connectedEditors.size === 0 after timer:
+            ──► 5s cleanup timer ──► handleSessionEnded()
+
+  SCENARIO 11 — B clicks "End Session":
+        │
+        ▼
+  Same as Scenario 1/2 but no partner to notify
+        ├─ history saved immediately
+        └─ navigate to /dashboard
+
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ NOTES
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+- No beforeunload handler: browser close/crash = WS disconnect (server-detected)
+- Navigate away via React Router also triggers socket disconnect via useEffect cleanup
+- sessionEndedRef = true blocks auto-reconnect after intentional End Session
+- partnerEndedRef = true blocks "Reconnecting..." UI after partner explicitly left
+- History is idempotent: session:saved:<userId> key prevents duplicate writes
+- 30s grace period is per-user and independent; both can be in grace simultaneously
+```

--- a/frontend/src/components/CollaborationPage.tsx
+++ b/frontend/src/components/CollaborationPage.tsx
@@ -373,7 +373,18 @@ export function CollaborationPage() {
   // --- 5a. End Session ---
   const handleEndSession = useCallback(async () => {
     sessionEndedRef.current = true;
-    editorSocketRef.current?.emit('end-session');
+    // Emit end-session and wait for server acknowledgement before disconnecting —
+    // otherwise disconnect fires before the event is handled
+    await new Promise<void>((resolve) => {
+      const socket = editorSocketRef.current;
+      if (socket?.connected) {
+        socket.emit('end-session', resolve);
+        // Fallback: disconnect anyway after 2s if server never acknowledges
+        setTimeout(resolve, 2000);
+      } else {
+        resolve();
+      }
+    });
     editorSocketRef.current?.disconnect();
     chatSocketRef.current?.disconnect();
     ydocRef.current?.destroy();


### PR DESCRIPTION
# Fix: Disconnect timer fires after user explicitly ends session

---

## Problem

When a user clicked "End Session", the frontend immediately called socket.disconnect() after emitting end-session.
Because socket events are not guaranteed to arrive in order, the disconnect event would often reach the server
before the end-session event was processed. This caused:
- The 30s disconnect timer to start for a user who had already intentionally left
- partner-ended being emitted twice (once from end-session, once from the timer)
- History being saved twice (duplicate Firestore writes)
- active_session being deleted even if the user had already joined a new session