### PR TITLE
Update dependencies on docker compose

### DIFF
--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -11,7 +11,6 @@ services:
       - "80:80"
     depends_on:
       - api-gateway
-      - collab-service
     restart: always
 
   # The Bouncer (Internal)
@@ -24,8 +23,9 @@ services:
       - ./api-gateway:/app
     depends_on:
       - user-service
-      - redis-sessions
-      - redis-auth
+      - question-service
+      - matching-service
+      - collab-service
     environment:
       - PYTHONUNBUFFERED=1
       - REDIS_SESSIONS_HOST=redis-sessions


### PR DESCRIPTION
API Gateway container now depends on user, question, matching, and collab services.