### PR TITLE
Horizontal Scaling for Collaboration Service

### DIFF
--- a/backend/collaboration-service/package-lock.json
+++ b/backend/collaboration-service/package-lock.json
@@ -9,9 +9,72 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@socket.io/redis-adapter": "^8.3.0",
+        "axios": "^1.6.0",
         "cors": "^2.8.6",
         "express": "^5.2.1",
-        "socket.io": "^4.8.3"
+        "redis": "^4.6.0",
+        "socket.io": "^4.8.3",
+        "yjs": "^13.6.18"
+      }
+    },
+    "node_modules/@redis/bloom": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-1.2.0.tgz",
+      "integrity": "sha512-HG2DFjYKbpNmVXsa0keLHp/3leGJz1mjh09f2RLGGLQZzSHpkmZWuwJbAvo3QcRY8p80m5+ZdXZdYOSBLlp7Cg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/client": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@redis/client/-/client-1.6.1.tgz",
+      "integrity": "sha512-/KCsg3xSlR+nCK8/8ZYSknYxvXHwubJrU82F3Lm1Fp6789VQ0/3RJKfsmRXjqfaTA++23CvC3hqmqe/2GEt6Kw==",
+      "license": "MIT",
+      "dependencies": {
+        "cluster-key-slot": "1.1.2",
+        "generic-pool": "3.9.0",
+        "yallist": "4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@redis/graph": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@redis/graph/-/graph-1.1.1.tgz",
+      "integrity": "sha512-FEMTcTHZozZciLRl6GiiIB4zGm5z5F3F6a6FZCyrfxdKOhFlGkiAqlexWMBzCi4DcRoyiOsuLfW+cjlGWyExOw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/json": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@redis/json/-/json-1.0.7.tgz",
+      "integrity": "sha512-6UyXfjVaTBTJtKNG4/9Z8PSpKE6XgSyEb8iwaqDcy+uKrd/DGYHTWkUdnQDyzm727V7p21WUMhsqz5oy65kPcQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/search": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@redis/search/-/search-1.2.0.tgz",
+      "integrity": "sha512-tYoDBbtqOVigEDMAcTGsRlMycIIjwMCgD8eR2t0NANeQmgK/lvxNAvYyb6bZDD4frHRhIHkJu2TBRvB0ERkOmw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/time-series": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-1.1.0.tgz",
+      "integrity": "sha512-c1Q99M5ljsIuc4YdaCwfUEXsofakb9c8+Zse2qxTadu8TalLXuAESzLvFAvNVbkmSlvlzIQOLpBCmWI9wTOt+g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
       }
     },
     "node_modules/@socket.io/component-emitter": {
@@ -19,6 +82,40 @@
       "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
       "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
       "license": "MIT"
+    },
+    "node_modules/@socket.io/redis-adapter": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/@socket.io/redis-adapter/-/redis-adapter-8.3.0.tgz",
+      "integrity": "sha512-ly0cra+48hDmChxmIpnESKrc94LjRL80TEmZVscuQ/WWkRP81nNj8W8cCGMqbI4L6NCuAaPRSzZF1a9GlAxxnA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "~4.3.1",
+        "notepack.io": "~3.0.1",
+        "uid2": "1.0.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "socket.io-adapter": "^2.5.4"
+      }
+    },
+    "node_modules/@socket.io/redis-adapter/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@types/cors": {
       "version": "2.8.19",
@@ -49,6 +146,23 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.14.0.tgz",
+      "integrity": "sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/base64id": {
@@ -120,6 +234,27 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/content-disposition": {
@@ -194,6 +329,15 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/depd": {
@@ -336,6 +480,21 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
@@ -415,6 +574,63 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -440,6 +656,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/generic-pool": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.9.0.tgz",
+      "integrity": "sha512-hymDOu5B53XvN4QT9dBmZxPX4CWhBPPLguTZ9MMFeFa/Kg0xWVfylOVNlJji/E7yTZWFd/q9GO5TxDLq156D7g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/get-intrinsic": {
@@ -496,6 +721,21 @@
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -572,6 +812,37 @@
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "license": "MIT"
     },
+    "node_modules/isomorphic.js": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.5.tgz",
+      "integrity": "sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==",
+      "license": "MIT",
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
+      }
+    },
+    "node_modules/lib0": {
+      "version": "0.2.117",
+      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.117.tgz",
+      "integrity": "sha512-DeXj9X5xDCjgKLU/7RR+/HQEVzuuEUiwldwOGsHK/sfAfELGWEyTcf0x+uOvCvK3O2zPmZePXWL85vtia6GyZw==",
+      "license": "MIT",
+      "dependencies": {
+        "isomorphic.js": "^0.2.4"
+      },
+      "bin": {
+        "0ecdsa-generate-keypair": "bin/0ecdsa-generate-keypair.js",
+        "0gentesthtml": "bin/gentesthtml.js",
+        "0serve": "bin/0serve.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -641,6 +912,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/notepack.io": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/notepack.io/-/notepack.io-3.0.1.tgz",
+      "integrity": "sha512-TKC/8zH5pXIAMVQio2TvVDTtPRX+DJPHDqjRbxogtFiByHyzKmy96RA0JtCQJ+WouyyL4A10xomQzgbUT+1jCg==",
+      "license": "MIT"
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -716,6 +993,15 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/qs": {
       "version": "6.15.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
@@ -753,6 +1039,23 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/redis": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-4.7.1.tgz",
+      "integrity": "sha512-S1bJDnqLftzHXHP8JsT5II/CtHWQrASX5K96REjWjlmWKrviSOLWmM7QnRLstAWsu1VBBV1ffV6DzCvxNP0UJQ==",
+      "license": "MIT",
+      "workspaces": [
+        "./packages/*"
+      ],
+      "dependencies": {
+        "@redis/bloom": "1.2.0",
+        "@redis/client": "1.6.1",
+        "@redis/graph": "1.1.1",
+        "@redis/json": "1.0.7",
+        "@redis/search": "1.2.0",
+        "@redis/time-series": "1.1.0"
       }
     },
     "node_modules/router": {
@@ -1016,6 +1319,15 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/uid2": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/uid2/-/uid2-1.0.0.tgz",
+      "integrity": "sha512-+I6aJUv63YAcY9n4mQreLUt0d4lvwkkopDNmpomkAUz0fAkEMV9pRWxN0EjhW1YfRhcuyHg2v3mwddCDW1+LFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
     "node_modules/undici-types": {
       "version": "7.18.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
@@ -1065,6 +1377,29 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC"
+    },
+    "node_modules/yjs": {
+      "version": "13.6.30",
+      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.30.tgz",
+      "integrity": "sha512-vv/9h42eCMC81ZHDFswuu/MKzkl/vyq1BhaNGfHyOonwlG4CJbQF4oiBBJPvfdeCt/PlVDWh7Nov9D34YY09uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "lib0": "^0.2.99"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=8.0.0"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
       }
     }
   }

--- a/backend/collaboration-service/package.json
+++ b/backend/collaboration-service/package.json
@@ -10,6 +10,7 @@
   "license": "ISC",
   "description": "",
   "dependencies": {
+    "@socket.io/redis-adapter": "^8.3.0",
     "axios": "^1.6.0",
     "cors": "^2.8.6",
     "express": "^5.2.1",

--- a/backend/collaboration-service/server.js
+++ b/backend/collaboration-service/server.js
@@ -35,14 +35,6 @@ subClient.on('error', (err) => console.error('Redis pubsub sub error:', err));
 
 // In-memory session state
 const sessions = new Map();
-// sessions.get(sessionId) = {
-//   ydoc: Y.Doc,
-//   connectedEditors: Set<string>,   // userIds currently connected via socket
-//   endedUsers: Set<string>,          // userIds who explicitly ended session
-//   userDisconnectTimers: Map<string, Timeout>,
-//   activeSocketIds: Map<string, string>,
-//   disconnectTimer: Timeout | null
-// }
 
 // Ticket validation middleware
 async function ticketMiddleware(socket, next) {
@@ -124,6 +116,7 @@ editorNs.on('connection', async (socket) => {
   }
 
   session.connectedEditors.add(userId);
+  await redisClient.sAdd(`session:${sessionId}:connectedEditors`, userId);
   console.log(`[connect] ${userId} ${isReconnect ? 'reconnected' : 'connected'} (socket=${socket.id}, session=${sessionId}, editors=${[...session.connectedEditors]})`);
   socket.join(sessionId);
 
@@ -185,16 +178,18 @@ editorNs.on('connection', async (socket) => {
     if (typeof ack === 'function') ack();
   });
 
-  socket.on('disconnect', () => {
+  socket.on('disconnect', async () => {
     session.connectedEditors.delete(userId);
+    await redisClient.sRem(`session:${sessionId}:connectedEditors`, userId);
 
     // If the user already explicitly ended, skip the disconnect timer entirely —
     // history is already saved and partner was already notified.
     if (session.endedUsers.has(userId)) {
       console.log(`[disconnect] ${userId} socket closed after explicit end-session, skipping timer (socket=${socket.id}, session=${sessionId})`);
 
-      // Still need to check if session needs cleanup (both users gone)
-      if (session.connectedEditors.size === 0) {
+      // Use Redis sCard — connectedEditors across ALL instances, not just this one
+      const remainingCount = await redisClient.sCard(`session:${sessionId}:connectedEditors`);
+      if (remainingCount === 0) {
         if (session.disconnectTimer) {
           clearTimeout(session.disconnectTimer);
         }
@@ -258,8 +253,9 @@ editorNs.on('connection', async (socket) => {
         editorNs.to(sessionId).emit('partner-ended', { userId });
       }
 
-      // Check if session needs cleanup
-      if (session.connectedEditors.size === 0) {
+      // Use Redis sCard — connectedEditors across ALL instances, not just this one
+      const remainingCount = await redisClient.sCard(`session:${sessionId}:connectedEditors`);
+      if (remainingCount === 0) {
         if (session.disconnectTimer) {
           clearTimeout(session.disconnectTimer);
           console.log(`[cancelTimer] Cleared previous session cleanup timer before setting new one (session=${sessionId})`);
@@ -393,6 +389,7 @@ async function handleSessionEnded(sessionId) {
     `session:${sessionId}:finalCode`,
     `session:${sessionId}:ydoc`,
     `session:${sessionId}:chat`,
+    `session:${sessionId}:connectedEditors`,
     `session:${sessionId}:saved:${meta.user1_id}`,
     `session:${sessionId}:saved:${meta.user2_id}`,
     `session:${sessionId}:activesocket:${meta.user1_id}`,

--- a/backend/collaboration-service/server.js
+++ b/backend/collaboration-service/server.js
@@ -224,6 +224,9 @@ editorNs.on('connection', async (socket) => {
     // Capture which socket triggered this disconnect
     const disconnectingSocketId = socket.id;
 
+    // Snapshot code at disconnect time — not after 30s when partner may have kept editing
+    const finalCode = session.ydoc.getText('code').toString();
+
     // Start 30s timer for this user — if they don't reconnect, treat as end-session
     console.log(`[setTimer] Started 30s disconnect timer for ${userId} (disconnectSocket=${disconnectingSocketId}, session=${sessionId})`);
 
@@ -242,8 +245,6 @@ editorNs.on('connection', async (socket) => {
       // before the server processes the end-session socket event)
       const activeSessionVal = await redisClient.get(`active_session:${userId}`);
       const restEndedEarly = activeSessionVal === null || activeSessionVal !== sessionId;
-
-      const finalCode = session.ydoc.getText('code').toString();
       try {
         await handleUserEnded(sessionId, userId, finalCode);
       } catch (err) {

--- a/backend/collaboration-service/server.js
+++ b/backend/collaboration-service/server.js
@@ -3,6 +3,7 @@ const http = require('http');
 const { Server } = require('socket.io');
 const cors = require('cors');
 const { createClient } = require('redis');
+const { createAdapter } = require('@socket.io/redis-adapter');
 const Y = require('yjs');
 const axios = require('axios');
 
@@ -23,7 +24,14 @@ const redisClient = createClient({
   socket: { host: process.env.REDIS_SESSIONS_HOST || 'redis-sessions', port: 6379 }
 });
 redisClient.on('error', (err) => console.error('Redis error:', err));
-redisClient.connect().then(() => console.log('Connected to redis-sessions'));
+
+// Redis clients dedicated to Socket.IO adapter (pub/sub)
+const pubClient = createClient({
+  socket: { host: process.env.REDIS_PUBSUB_HOST || 'redis-pubsub', port: 6379 }
+});
+const subClient = pubClient.duplicate();
+pubClient.on('error', (err) => console.error('Redis pubsub pub error:', err));
+subClient.on('error', (err) => console.error('Redis pubsub sub error:', err));
 
 // In-memory session state
 const sessions = new Map();
@@ -99,8 +107,9 @@ editorNs.on('connection', async (socket) => {
   // Check before setting — if an entry exists, this user was here before
   const isReconnect = session.activeSocketIds.has(userId);
 
-  // Register this as the latest socket for the user
+  // Register this as the latest socket for the user (in-memory for same-instance, Redis for cross-instance)
   session.activeSocketIds.set(userId, socket.id);
+  await redisClient.set(`session:${sessionId}:activesocket:${userId}`, socket.id);
 
   // Clear any disconnect timers for this user (they reconnected in time)
   if (session.userDisconnectTimers.has(userId)) {
@@ -220,9 +229,10 @@ editorNs.on('connection', async (socket) => {
 
     const userTimer = setTimeout(async () => {
       session.userDisconnectTimers.delete(userId);
-      const currentSocketId = session.activeSocketIds.get(userId);
+      // Read from Redis so cross-instance reconnects are visible (Instance 2 overwrites this key on reconnect)
+      const currentSocketId = await redisClient.get(`session:${sessionId}:activesocket:${userId}`);
 
-      // If the user reconnected, their active socket ID will differ from the one that disconnected
+      // If the user reconnected (on any instance), their active socket ID will differ from the one that disconnected
       if (currentSocketId !== disconnectingSocketId) {
         console.log(`[timerFired] ${userId} reconnected via new socket (old=${disconnectingSocketId}, new=${currentSocketId}), skipping (session=${sessionId})`);
         return;
@@ -383,7 +393,9 @@ async function handleSessionEnded(sessionId) {
     `session:${sessionId}:ydoc`,
     `session:${sessionId}:chat`,
     `session:${sessionId}:saved:${meta.user1_id}`,
-    `session:${sessionId}:saved:${meta.user2_id}`
+    `session:${sessionId}:saved:${meta.user2_id}`,
+    `session:${sessionId}:activesocket:${meta.user1_id}`,
+    `session:${sessionId}:activesocket:${meta.user2_id}`
   );
   console.log(`[session-cleanup] Redis session keys deleted (session=${sessionId})`);
 
@@ -473,7 +485,24 @@ app.post('/collab/end-session/:sessionId', async (req, res) => {
   res.json({ detail: 'Active session cleared' });
 });
 
-const PORT = process.env.PORT || 4000;
-server.listen(PORT, () => {
-  console.log(`Collaboration Service running on port ${PORT}`);
+Promise.all([
+  redisClient.connect().then(() => console.log('Connected to redis-sessions')),
+  pubClient.connect(),
+  subClient.connect(),
+]).then(() => {
+  io.adapter(createAdapter(pubClient, subClient));
+  console.log('Socket.IO Redis adapter attached');
+
+  const PORT = process.env.PORT || 4000;
+  server.listen(PORT, () => {
+    console.log(`Collaboration Service running on port ${PORT}`);
+  });
+
+  process.on('SIGTERM', () => {
+    console.log('SIGTERM received, closing connections...');
+    io.close(() => {
+      console.log('All Socket.IO connections closed');
+      process.exit(0);
+    });
+  });
 });

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -51,7 +51,6 @@ services:
 
   collab-service:
     build: ./collaboration-service
-    container_name: collab-service
     expose:
       - "4000"
     volumes:
@@ -59,9 +58,11 @@ services:
       - /app/node_modules
     depends_on:
       - redis-sessions
+      - redis-pubsub
       - history-service
     environment:
       - REDIS_SESSIONS_HOST=redis-sessions
+      - REDIS_PUBSUB_HOST=redis-pubsub
 
   question-service:
     build: ./question-service
@@ -112,5 +113,12 @@ services:
   redis-auth:
     image: redis:7-alpine
     container_name: redis-auth
+    expose:
+      - "6379"
+
+  # Dedicated pub/sub bus for Socket.IO multi-instance adapter
+  redis-pubsub:
+    image: redis:7-alpine
+    container_name: redis-pubsub
     expose:
       - "6379"

--- a/backend/nginx.conf
+++ b/backend/nginx.conf
@@ -10,17 +10,23 @@ http {
     client_header_buffer_size 4k;
     large_client_header_buffers 4 16k;
 
+    # Load balancer for collab-service replicas
+    # ip_hash ensures sticky sessions — a client always hits the same instance
+    upstream collab_upstream {
+        ip_hash;
+        server collab-service:4000;
+    }
+
     server {
         listen 80;
 
         location /socket.io/ {
-            set $upstream_collab collab-service;
-
-            proxy_pass http://$upstream_collab:4000;
+            proxy_pass http://collab_upstream;
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection "upgrade";
             proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
         }
 
     location /api/ {


### PR DESCRIPTION
## Descriptions

Enables the collaboration service to run as multiple instances behind a load balancer without losing session state or dropping real-time sync between users.

Previously, a single collab-service container held all Socket.IO room state in memory. Scaling to multiple instances would silently break Yjs sync and chat — users on different instances would never see each other's updates.

  ---

## Test

### Setup
1. Remove ip_hash from nginx.conf
2. Start 5 instances:
docker compose down -v
docker compose up --build --scale collab-service=5

### How to Test
1. Open Chrome → log in as User A → join a session
2. Wait 3 seconds
3. Open Edge → log in as User B → join the same session
4. Check logs, confirm they landed on different instances:
5. Type in the editor as User A → verify User B sees it
6. Send a chat as User B → verify User A sees it
