### PR TITLE
Fix same user from entering multiple sessions

### DIFF
--- a/backend/api-gateway/main.py
+++ b/backend/api-gateway/main.py
@@ -215,10 +215,26 @@ async def gateway_proxy(request: Request, path: str):
     user_headers = {}
     if not is_public:
         decoded_token = await verify_token(request)
-        user_headers["X-User-Id"] = decoded_token.get("uid")
+        uid = decoded_token.get("uid")
+        user_headers["X-User-Id"] = uid
 
         if "role" in decoded_token:
             user_headers["X-User-Role"] = decoded_token.get("role")
+
+        # Block queue entry if the user is already in an active collaboration session.
+        # active_session:{uid} is set by /session/init and cleared when the session ends.
+        if request.method == "POST" and path == "matching/find-pair":
+            try:
+                active = await redis_sessions.get(f"active_session:{uid}")
+                if active:
+                    raise HTTPException(
+                        status_code=409,
+                        detail="ALREADY_IN_SESSION"
+                    )
+            except HTTPException:
+                raise
+            except Exception as e:
+                print(f"Session check failed (failing open): {e}")
 
     forwarded_headers = {
         k: v for k, v in request.headers.items()

--- a/frontend/src/components/MatchingPage.tsx
+++ b/frontend/src/components/MatchingPage.tsx
@@ -140,6 +140,9 @@ export function MatchingPage() {
         } else if (response.status === 400) {
           toast.error("You are already in the queue!");
           handleCancelClick();
+        } else if (response.status === 409) {
+          toast.error("You already have an active session. Please end it before starting a new match.");
+          handleCancelClick();
         } else if (!response.ok) {
           const errData = await response.json().catch(() => ({}));
           if (response.status === 401 && errData.detail === 'ACCOUNT_DELETED') {


### PR DESCRIPTION
Matching API call now checks for `active_session:{uid}` on `redis-sessions`. If the user is already matched, returns a 409 Error.
This prevents the same logged in user from entering in two separate collaboration sessions.

Fixes #88 